### PR TITLE
Throw SVGException instead of IAE

### DIFF
--- a/svg-core/src/main/java/com/kitfox/svg/ShapeElement.java
+++ b/svg-core/src/main/java/com/kitfox/svg/ShapeElement.java
@@ -160,7 +160,11 @@ abstract public class ShapeElement extends RenderableElement
                         SVGElement ele = diagram.getUniverse().getElement(uri);
                         if (ele != null)
                         {
-                            fillPaint = ((FillElement)ele).getPaint(bounds, xform);
+                            try {
+                                fillPaint = ((FillElement)ele).getPaint(bounds, xform);
+                            } catch (IllegalArgumentException e) {
+                                throw new SVGException(e);
+                            }
                         }
                     }
                 }


### PR DESCRIPTION
We have upgraded to version 1.1.0 in JOSM: https://josm.openstreetmap.de/changeset/10787/josm
The switch from batik to Java2D API now detects more invalid cases. For example, we have two SVG files which were previously loaded and now cause errors:

https://josm.openstreetmap.de/browser/josm/trunk/images/presets/sport/volleyball.svg?rev=10706
https://josm.openstreetmap.de/browser/josm/trunk/images/presets/shop/diy_store.svg?rev=10706

The error are:
    java.lang.IllegalArgumentException: Keyframe fractions must be increasing: 1.0
    java.lang.IllegalArgumentException: Keyframe fractions must be increasing: 0.5

They match the following SVG code:

    <linearGradient
       id="linearGradient1879">
      <stop
         id="stop1880"
         offset="0.0000000"
         style="stop-color:#002723;stop-opacity:1.0000000;" />
      <stop
         id="stop1883"
         offset="1.0000000"
         style="stop-color:#000000;stop-opacity:0.49803922;" />
      <stop
         id="stop1881"
         offset="1.0000000"
         style="stop-color:#ffffff;stop-opacity:0.0000000;" />
    </linearGradient>

and

    <linearGradient
       id="linearGradient8962">
      <stop
         id="stop8964"
         offset="0.00000000"
         style="stop-color:#fffdff;stop-opacity:1.0000000;" />
      <stop
         id="stop8970"
         offset="0.50000000"
         style="stop-color:#000000;stop-opacity:0.49803922;" />
      <stop
         id="stop8972"
         offset="0.50000000"
         style="stop-color:#000000;stop-opacity:0.24705882;" />
      <stop
         id="stop8966"
         offset="1"
         style="stop-color:#000000;stop-opacity:0;" />
    </linearGradient>

The offsets are not strictly increasing.