### PR TITLE
Fix issue #7 (Fixed height, but variable width to keep aspect ratio)

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ Projects using SVG Salamander
 * [Tygron](http://www.tygron.com/) - Serious games illustrating urban planning and climate change.
 * [NeoLogica](http://www.neologica.it/eng/Home.php) - Medical imaging.
 * [JOSM](https://josm.openstreetmap.de/) - Java OpenStreetMap Editor.
+* [Freeplane](http://freeplane.org) - Java program for working with Mind Maps
 
 License
 -------

--- a/svg-core/src/main/java/com/kitfox/svg/app/beans/SVGIcon.java
+++ b/svg-core/src/main/java/com/kitfox/svg/app/beans/SVGIcon.java
@@ -117,8 +117,7 @@ public class SVGIcon extends ImageIcon
     /**
      * @return height of this icon
      */
-    @Override
-    public int getIconHeight()
+    public int getIconHeightIgnoreAutosize()
     {
         if (preferredSize != null &&
                 (autosize == AUTOSIZE_VERT || autosize == AUTOSIZE_STRETCH 
@@ -138,8 +137,8 @@ public class SVGIcon extends ImageIcon
     /**
      * @return width of this icon
      */
-    @Override
-    public int getIconWidth()
+
+    public int getIconWidthIgnoreAutosize()
     {
         if (preferredSize != null &&
                 (autosize == AUTOSIZE_HORIZ || autosize == AUTOSIZE_STRETCH 
@@ -155,6 +154,49 @@ public class SVGIcon extends ImageIcon
         }
         return (int)diagram.getWidth();
     }
+    
+    private boolean isAutoSizeBestFitUseFixedHeight(final int iconWidthIgnoreAutosize, final int iconHeightIgnoreAutosize,
+    		final SVGDiagram diagram)
+    {
+    	return iconHeightIgnoreAutosize/diagram.getHeight() < iconWidthIgnoreAutosize/diagram.getWidth();
+    }
+    
+    @Override
+    public int getIconWidth()
+    {
+    	final int iconWidthIgnoreAutosize = getIconWidthIgnoreAutosize();
+    	final int iconHeightIgnoreAutosize = getIconHeightIgnoreAutosize();
+		final SVGDiagram diagram = svgUniverse.getDiagram(svgURI);
+    	if (preferredSize != null && (autosize == AUTOSIZE_VERT ||
+    			                     (autosize == AUTOSIZE_BESTFIT && isAutoSizeBestFitUseFixedHeight(iconWidthIgnoreAutosize, iconHeightIgnoreAutosize, diagram))))
+    	{
+    		final double aspectRatio = diagram.getHeight()/diagram.getWidth();
+    		return (int)(iconHeightIgnoreAutosize / aspectRatio);
+    	}
+    	else
+    	{
+    		return iconWidthIgnoreAutosize;
+    	}
+    }
+    
+    @Override
+    public int getIconHeight()
+    {
+    	final int iconWidthIgnoreAutosize = getIconWidthIgnoreAutosize();
+    	final int iconHeightIgnoreAutosize = getIconHeightIgnoreAutosize();
+		final SVGDiagram diagram = svgUniverse.getDiagram(svgURI);
+    	if (preferredSize != null && (autosize == AUTOSIZE_HORIZ ||
+    	                              (autosize == AUTOSIZE_BESTFIT && !isAutoSizeBestFitUseFixedHeight(iconWidthIgnoreAutosize, iconHeightIgnoreAutosize, diagram))))
+    	{
+    		final double aspectRatio = diagram.getHeight()/diagram.getWidth();
+    		return (int)(iconWidthIgnoreAutosize * aspectRatio);
+    	}
+    	else
+    	{
+    		return iconHeightIgnoreAutosize;
+    	}
+    }
+
     
     /**
      * Draws the icon to the specified component.
@@ -221,8 +263,8 @@ public class SVGIcon extends ImageIcon
             return;
         }
         
-        final int width = getIconWidth();
-        final int height = getIconHeight();
+        final int width = getIconWidthIgnoreAutosize();
+        final int height = getIconHeightIgnoreAutosize();
 //        int width = getWidth();
 //        int height = getHeight();
         


### PR DESCRIPTION
Dear svgSalamander maintainer,

this pull request fixes an issue where AUTOSIZE_* is not honored in SVGIcon.getIcon{Width,Height}().
Thus, the extent of the icons is wrong when using AUTOSIZE_VERT, AUTOSIZE_HORIZ or
AUTOSIZE_BESTFIT.

The patch is straightforward, but please tell me if you have any questions or
something needs to be cleaned up.

Cheers and Best Regards,
Felix
