### PR TITLE
#11 - svgSalamander fix for CVE-2017-5617 was incomplete

### DIFF
--- a/svg-core/src/main/java/com/kitfox/svg/ImageSVG.java
+++ b/svg-core/src/main/java/com/kitfox/svg/ImageSVG.java
@@ -113,28 +113,21 @@ public class ImageSVG extends RenderableElement
         {
             if (getPres(sty.setName("xlink:href")))
             {
-                
-                
                 URI src = sty.getURIValue(getXMLBase());
                 if ("data".equals(src.getScheme()))
                 {
                     imageSrc = new URL(null, src.toASCIIString(), new Handler());
                 }
-                else 
+                else if (!diagram.getUniverse().isImageDataInlineOnly())
                 {
-                    
-                    if (!diagram.getUniverse().isImageDataInlineOnly())
+                    try
                     {
-                        try
-                        {
-                            imageSrc = src.toURL();
-                        } catch (Exception e)
-                        {
-                            Logger.getLogger(SVGConst.SVG_LOGGER).log(Level.WARNING,
-                                "Could not parse xlink:href " + src, e);
-    //                        e.printStackTrace();
-                            imageSrc = null;
-                        }
+                        imageSrc = src.toURL();
+                    } catch (Exception e)
+                    {
+                        Logger.getLogger(SVGConst.SVG_LOGGER).log(Level.WARNING,
+                            "Could not parse xlink:href " + src, e);
+                        imageSrc = null;
                     }
                 }
             }
@@ -143,32 +136,33 @@ public class ImageSVG extends RenderableElement
             throw new SVGException(e);
         }
 
-        diagram.getUniverse().registerImage(imageSrc);
-
-        //Set widths if not set
-        BufferedImage img = diagram.getUniverse().getImage(imageSrc);
-        if (img == null)
+        if (imageSrc != null)
         {
+            diagram.getUniverse().registerImage(imageSrc);
+
+            //Set widths if not set
+            BufferedImage img = diagram.getUniverse().getImage(imageSrc);
+            if (img == null)
+            {
+                xform = new AffineTransform();
+                bounds = new Rectangle2D.Float();
+                return;
+            }
+
+            if (width == 0)
+            {
+                width = img.getWidth();
+            }
+            if (height == 0)
+            {
+                height = img.getHeight();
+            }
+
+            //Determine image xform
             xform = new AffineTransform();
-            bounds = new Rectangle2D.Float();
-            return;
+            xform.translate(this.x, this.y);
+            xform.scale(this.width / img.getWidth(), this.height / img.getHeight());
         }
-
-        if (width == 0)
-        {
-            width = img.getWidth();
-        }
-        if (height == 0)
-        {
-            height = img.getHeight();
-        }
-
-        //Determine image xform
-        xform = new AffineTransform();
-//        xform.setToScale(this.width / img.getWidth(), this.height / img.getHeight());
-//        xform.translate(this.x, this.y);
-        xform.translate(this.x, this.y);
-        xform.scale(this.width / img.getWidth(), this.height / img.getHeight());
 
         bounds = new Rectangle2D.Float(this.x, this.y, this.width, this.height);
     }
@@ -342,16 +336,16 @@ public class ImageSVG extends RenderableElement
             {
                 URI src = sty.getURIValue(getXMLBase());
 
-                URL newVal;
+                URL newVal = null;
                 if ("data".equals(src.getScheme()))
                 {
                     newVal = new URL(null, src.toASCIIString(), new Handler());
-                } else
+                } else if (!diagram.getUniverse().isImageDataInlineOnly())
                 {
                     newVal = src.toURL();
                 }
 
-                if (!newVal.equals(imageSrc))
+                if (newVal != null && !newVal.equals(imageSrc))
                 {
                     imageSrc = newVal;
                     shapeChange = true;


### PR DESCRIPTION
The vulnerability reported in #11 was still here. `imageSrc` was set in `updateTime(double)`, then evaluated in a later `updateTime` call that triggered a network call through `ImageIo.read`:

```
        at javax.imageio.ImageIO.read(ImageIO.java:1395)
	at com.kitfox.svg.SVGUniverse.registerImage(SVGUniverse.java:266)
	at com.kitfox.svg.ImageSVG.build(ImageSVG.java:142)
	at com.kitfox.svg.SVGElement.build(SVGElement.java:412)
	at com.kitfox.svg.TransformableElement.build(TransformableElement.java:92)
	at com.kitfox.svg.RenderableElement.build(RenderableElement.java:78)
	at com.kitfox.svg.SVGRoot.build(SVGRoot.java:104)
	at com.kitfox.svg.SVGRoot.updateTime(SVGRoot.java:467)
	at com.kitfox.svg.SVGDiagram.updateTime(SVGDiagram.java:243)
	at com.kitfox.svg.SVGUniverse.loadSVG(SVGUniverse.java:616)
	at com.kitfox.svg.SVGUniverse.loadSVG(SVGUniverse.java:468)
	at com.kitfox.svg.SVGUniverse.loadSVG(SVGUniverse.java:445)
```