### PR TITLE
Make XMLReader threadsafe

### DIFF
--- a/svg-core/src/main/java/com/kitfox/svg/SVGUniverse.java
+++ b/svg-core/src/main/java/com/kitfox/svg/SVGUniverse.java
@@ -576,15 +576,11 @@ public class SVGUniverse implements Serializable
         }
     }
 
-    private XMLReader getXMLReaderCached() throws SAXException, ParserConfigurationException
+    private XMLReader getXMLReader() throws SAXException, ParserConfigurationException
     {
-        if (cachedReader == null)
-        {
-            SAXParserFactory factory = SAXParserFactory.newInstance();
-            factory.setNamespaceAware(true);
-            cachedReader = factory.newSAXParser().getXMLReader();
-        }
-        return cachedReader;
+        SAXParserFactory factory = SAXParserFactory.newInstance();
+        factory.setNamespaceAware(true);
+        return factory.newSAXParser().getXMLReader();
     }
 
     protected URI loadSVG(URI xmlBase, InputSource is)
@@ -600,7 +596,7 @@ public class SVGUniverse implements Serializable
         try
         {
             // Parse the input
-            XMLReader reader = getXMLReaderCached();
+            XMLReader reader = getXMLReader();
             reader.setEntityResolver(
                 new EntityResolver()
                 {

--- a/svg-core/src/main/java/com/kitfox/svg/SVGUniverse.java
+++ b/svg-core/src/main/java/com/kitfox/svg/SVGUniverse.java
@@ -98,9 +98,7 @@ public class SVGUniverse implements Serializable
      */
     protected double curTime = 0.0;
     private boolean verbose = false;
-    //Cache reader for efficiency
-    XMLReader cachedReader;
-    
+
     //If true, <imageSVG> elements will only load image data that is included using inline data: uris
     private boolean imageDataInlineOnly = false;
     


### PR DESCRIPTION
Parsing multiple XML files in different threads will return an error:

JAXB Error : FWK005 parse may not be called while parsing

