### PR TITLE
Added automatic module name

### DIFF
--- a/svg-core/pom.xml
+++ b/svg-core/pom.xml
@@ -81,6 +81,18 @@
                 </executions>
             </plugin>
             <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-jar-plugin</artifactId>
+                <version>3.1.2</version>
+                <configuration>
+                    <archive>
+                        <manifestEntries>
+                            <Automatic-Module-Name>com.kitfox.svg</Automatic-Module-Name>
+                        </manifestEntries>
+                    </archive>
+                </configuration>
+            </plugin>
+            <plugin>
                 <groupId>org.sonatype.plugins</groupId>
                 <artifactId>nexus-staging-maven-plugin</artifactId>
                 <version>1.6.8</version>


### PR DESCRIPTION
Since Java 9, a Java project can be modular with the introduction of the Java Platform Module System. A Java module uses other modules by referencing their module names in its `module-info.java` file.

This commit adds the entry `Automatic-Module-Name: com.kitfox.svg` to the manifest file, which defines a stable module name for this project (otherwise an unstable module name based on the name of the jar file will be used). Having a stable module name ensures that this project can be used and referenced in a stable way in modular Java projects.

Since this commit only adds an entry to the manifest file, older Java targets will not be affected.

I used `com.kitfox.svg` as the module name, based on the main package name of the code.