### PR TITLE
cache SAXParser per thread to make it thread safe (see also PR #39)

### DIFF
--- a/svg-core/src/main/java/com/kitfox/svg/SVGUniverse.java
+++ b/svg-core/src/main/java/com/kitfox/svg/SVGUniverse.java
@@ -577,15 +577,17 @@ public class SVGUniverse implements Serializable
         }
     }
 
-    static SAXParser saxParser;
-    
+    static ThreadLocal<SAXParser> threadSAXParser = new ThreadLocal<SAXParser>();
+
     private XMLReader getXMLReader() throws SAXException, ParserConfigurationException
     {
+        SAXParser saxParser = threadSAXParser.get();
         if (saxParser == null)
         {
             SAXParserFactory saxParserFactory = SAXParserFactory.newInstance();
             saxParserFactory.setNamespaceAware(true);
             saxParser = saxParserFactory.newSAXParser();
+            threadSAXParser.set(saxParser);
         }
         return saxParser.getXMLReader();
     }


### PR DESCRIPTION
This PR changes the XML parser caching so that each thread uses its own instance.

This is to ensure compatibility with previous versions, prior to commit a692f0409181683d2da54741e52bd88794ab164e, which actually has undone PR #39.

Uses a `java.lang.ThreadLocal` object to store one `SAXParser` instance per thread.
If a thread goes away, the `SAXParser` used for this thread is garbage collected.