### PR TITLE
Implement Masks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,5 @@
 /svg-example/.classpath
 /svg-example/.project
 /svg-example/.settings
+**/*.iml
+**/.idea/

--- a/svg-core/src/main/java/com/kitfox/svg/Circle.java
+++ b/svg-core/src/main/java/com/kitfox/svg/Circle.java
@@ -93,7 +93,7 @@ public class Circle extends ShapeElement
     }
 
     @Override
-    public void render(Graphics2D g) throws SVGException
+    protected void doRender(Graphics2D g) throws SVGException
     {
         beginLayer(g);
         renderShape(g, circle);

--- a/svg-core/src/main/java/com/kitfox/svg/Ellipse.java
+++ b/svg-core/src/main/java/com/kitfox/svg/Ellipse.java
@@ -99,7 +99,7 @@ public class Ellipse extends ShapeElement
     }
 
     @Override
-    public void render(Graphics2D g) throws SVGException
+    protected void doRender(Graphics2D g) throws SVGException
     {
         beginLayer(g);
         renderShape(g, ellipse);

--- a/svg-core/src/main/java/com/kitfox/svg/Group.java
+++ b/svg-core/src/main/java/com/kitfox/svg/Group.java
@@ -146,7 +146,7 @@ public class Group extends ShapeElement
     }
 
     @Override
-    public void render(Graphics2D g) throws SVGException
+    protected void doRender(Graphics2D g) throws SVGException
     {
         //Don't process if not visible
         StyleAttribute styleAttrib = new StyleAttribute();

--- a/svg-core/src/main/java/com/kitfox/svg/Group.java
+++ b/svg-core/src/main/java/com/kitfox/svg/Group.java
@@ -100,7 +100,7 @@ public class Group extends ShapeElement
     }
 
     @Override
-    void pick(Point2D point, boolean boundingBox, List<List<SVGElement>> retVec) throws SVGException
+    protected void doPick(Point2D point, boolean boundingBox, List<List<SVGElement>> retVec) throws SVGException
     {
         Point2D xPoint = new Point2D.Double(point.getX(), point.getY());
         if (xform != null)
@@ -126,7 +126,7 @@ public class Group extends ShapeElement
     }
 
     @Override
-    void pick(Rectangle2D pickArea, AffineTransform ltw, boolean boundingBox, List<List<SVGElement>> retVec) throws SVGException
+    protected void doPick(Rectangle2D pickArea, AffineTransform ltw, boolean boundingBox, List<List<SVGElement>> retVec) throws SVGException
     {
         if (xform != null)
         {

--- a/svg-core/src/main/java/com/kitfox/svg/ImageSVG.java
+++ b/svg-core/src/main/java/com/kitfox/svg/ImageSVG.java
@@ -206,7 +206,7 @@ public class ImageSVG extends RenderableElement
     }
 
     @Override
-    public void render(Graphics2D g) throws SVGException
+    protected void doRender(Graphics2D g) throws SVGException
     {
         StyleAttribute styleAttrib = new StyleAttribute();
         if (getStyle(styleAttrib.setName("visibility")))

--- a/svg-core/src/main/java/com/kitfox/svg/ImageSVG.java
+++ b/svg-core/src/main/java/com/kitfox/svg/ImageSVG.java
@@ -188,7 +188,7 @@ public class ImageSVG extends RenderableElement
     }
 
     @Override
-    void pick(Point2D point, boolean boundingBox, List<List<SVGElement>> retVec) throws SVGException
+    protected void doPick(Point2D point, boolean boundingBox, List<List<SVGElement>> retVec) throws SVGException
     {
         if (getBoundingBox().contains(point))
         {
@@ -197,7 +197,7 @@ public class ImageSVG extends RenderableElement
     }
 
     @Override
-    void pick(Rectangle2D pickArea, AffineTransform ltw, boolean boundingBox, List<List<SVGElement>> retVec) throws SVGException
+    protected void doPick(Rectangle2D pickArea, AffineTransform ltw, boolean boundingBox, List<List<SVGElement>> retVec) throws SVGException
     {
         if (ltw.createTransformedShape(getBoundingBox()).intersects(pickArea))
         {

--- a/svg-core/src/main/java/com/kitfox/svg/Line.java
+++ b/svg-core/src/main/java/com/kitfox/svg/Line.java
@@ -99,7 +99,7 @@ public class Line extends ShapeElement
     }
 
     @Override
-    public void render(Graphics2D g) throws SVGException
+    protected void doRender(Graphics2D g) throws SVGException
     {
         beginLayer(g);
         renderShape(g, line);

--- a/svg-core/src/main/java/com/kitfox/svg/Marker.java
+++ b/svg-core/src/main/java/com/kitfox/svg/Marker.java
@@ -147,12 +147,12 @@ public class Marker extends Group
     }
 
     @Override
-    public void render(Graphics2D g) throws SVGException
+    protected void doRender(Graphics2D g) throws SVGException
     {
         AffineTransform oldXform = g.getTransform();
         g.transform(markerXform);
 
-        super.render(g);
+        super.doRender(g);
 
         g.setTransform(oldXform);
     }
@@ -171,7 +171,7 @@ public class Marker extends Group
 
         g.transform(markerXform);
 
-        super.render(g);
+        super.doRender(g);
 
         g.setTransform(cacheXform);
     }

--- a/svg-core/src/main/java/com/kitfox/svg/Mask.java
+++ b/svg-core/src/main/java/com/kitfox/svg/Mask.java
@@ -89,9 +89,19 @@ public class Mask extends Group
         elementGraphics.drawImage(maskImage, 0, 0, null);
         elementGraphics.dispose();
 
-        AffineTransform imgTransform = AffineTransform.getTranslateInstance(elementBounds.x, elementBounds.y);
-        imgTransform.scale(1 / scaleX, 1 / scaleY);
-        gg.drawImage(elementImage, imgTransform, null);
+        // Instead of scaling the current graphics object by (1 / scaleX, 1 / scaleY)
+        // we manually set the scale to (1.0, 1.0). Because we ensured that elementImage has
+        // the correct size it won't have to be rescaled while painting. This avoids introducing
+        // unnecessary blurring.
+        AffineTransform imgTransform = new AffineTransform(
+                1.0, transform.getShearY(),
+                transform.getShearX(), 1.0,
+                transform.getTranslateX(), transform.getTranslateY());
+        gg.setTransform(imgTransform);
+        int destX = (int) (elementBounds.x * scaleX);
+        int destY = (int) (elementBounds.y * scaleY);
+        gg.drawImage(elementImage, destX, destY, null);
+        gg.setTransform(transform);
     }
 
     private BufferedImage paintToBuffer(Graphics2D g, double scaleX, double scaleY,

--- a/svg-core/src/main/java/com/kitfox/svg/Mask.java
+++ b/svg-core/src/main/java/com/kitfox/svg/Mask.java
@@ -1,0 +1,268 @@
+/*
+ * SVG Salamander
+ * Copyright (c) 2004, Mark McKay
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or
+ * without modification, are permitted provided that the following
+ * conditions are met:
+ *
+ *   - Redistributions of source code must retain the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer.
+ *   - Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/or other materials
+ *     provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ * INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+ * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+ * OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ * Mark McKay can be contacted at mark@kitfox.com.  Salamander and other
+ * projects can be found at http://www.kitfox.com
+ *
+ * Created on January 26, 2004, 1:56 AM
+ */
+package com.kitfox.svg;
+
+import java.awt.Color;
+import java.awt.Composite;
+import java.awt.CompositeContext;
+import java.awt.Graphics2D;
+import java.awt.Rectangle;
+import java.awt.RenderingHints;
+import java.awt.geom.AffineTransform;
+import java.awt.geom.Point2D;
+import java.awt.geom.Rectangle2D;
+import java.awt.image.BufferedImage;
+import java.awt.image.ColorModel;
+import java.awt.image.Raster;
+import java.awt.image.WritableRaster;
+import java.util.List;
+
+/**
+ * Implements the mask element.
+ *
+ * @author Jannis Weis
+ */
+public class Mask extends Group
+{
+    public static final String TAG_NAME = "mask";
+
+    @Override
+    public String getTagName() {
+        return TAG_NAME;
+    }
+
+    @Override
+    public void render(Graphics2D g)
+    { }
+
+    public void renderElement(Graphics2D g, RenderableElement element) throws SVGException
+    {
+        AffineTransform transform = g.getTransform();
+        double scaleX = transform.getScaleX();
+        double scaleY = transform.getScaleY();
+
+        Graphics2D gg = (Graphics2D) g.create();
+        Rectangle elementBounds = element.getBoundingBox().getBounds();
+
+        BufferedImage elementImage = paintToBuffer(gg, scaleX, scaleY, elementBounds, element, null);
+        // Draw the mask image. Implicitly the mask is empty i.e. has a completely black background.
+        // We can't draw the mask directly to the elementImage using the mask composite as
+        // masks may change the mask value a location at any time during mask realization.
+        BufferedImage maskImage = paintToBuffer(gg, scaleX, scaleY, elementBounds, this, Color.BLACK);
+
+        Graphics2D elementGraphics = (Graphics2D) elementImage.getGraphics();
+        elementGraphics.setRenderingHints(gg.getRenderingHints());
+        elementGraphics.setComposite(createMaskComposite());
+        elementGraphics.drawImage(maskImage, 0, 0, null);
+        elementGraphics.dispose();
+
+        AffineTransform imgTransform = AffineTransform.getTranslateInstance(elementBounds.x, elementBounds.y);
+        imgTransform.scale(1 / scaleX, 1 / scaleY);
+        gg.drawImage(elementImage, imgTransform, null);
+    }
+
+    private BufferedImage paintToBuffer(Graphics2D g, double scaleX, double scaleY,
+                                        Rectangle srcBounds, RenderableElement element,
+                                        Color bgColor) throws SVGException
+    {
+        return paintToBuffer(g, scaleX, scaleY, srcBounds, element, bgColor, false);
+    }
+
+    private BufferedImage paintToBuffer(Graphics2D g, double scaleX, double scaleY,
+                                        Rectangle srcBounds, RenderableElement element,
+                                        Color bgColor, boolean preScaledBounds) throws SVGException
+    {
+        int buffX = srcBounds.x;
+        int buffY = srcBounds.y;
+        int buffWidth = srcBounds.width;
+        int buffHeight = srcBounds.height;
+        if (!preScaledBounds)
+        {
+            buffX *= scaleX;
+            buffY *= scaleY;
+            buffWidth *= scaleX;
+            buffHeight *= scaleY;
+        }
+        BufferedImage img = new BufferedImage(buffWidth, buffHeight, BufferedImage.TYPE_INT_ARGB);
+        Graphics2D imgGraphics = (Graphics2D) img.getGraphics();
+        if (g != null)
+        {
+            imgGraphics.setRenderingHints(g.getRenderingHints());
+        }
+        if (bgColor != null)
+        {
+            imgGraphics.setColor(bgColor);
+            imgGraphics.fillRect(0,0, img.getWidth(), img.getHeight());
+        }
+        imgGraphics.translate(-buffX, -buffY);
+        imgGraphics.scale(scaleX, scaleY);
+        element.doRender(imgGraphics);
+        imgGraphics.dispose();
+        return img;
+    }
+
+    private Composite createMaskComposite()
+    {
+        return new MaskComposite();
+    }
+
+    @Override
+    void pick(Point2D point, boolean boundingBox, List<List<SVGElement>> retVec)
+    {
+    }
+
+    @Override
+    void pick(Rectangle2D pickArea, AffineTransform ltw, boolean boundingBox, List<List<SVGElement>> retVec)
+    {
+    }
+
+    public void pickElement(Point2D point, boolean boundingBox,
+                            List<List<SVGElement>> retVec, RenderableElement element) throws SVGException
+    {
+        if (boundingBox)
+        {
+            element.doPick(point, true, retVec);
+        } else
+        {
+            Rectangle pickPoint = new Rectangle((int) point.getX(), (int) point.getY(), 1, 1);
+            BufferedImage img = paintToBuffer(null, 1f, 1f, pickPoint, this, Color.BLACK);
+            // Only try picking the element if the picked point is visible.
+            if (luminanceToAlpha(img.getRGB(0, 0)) > 0)
+            {
+                element.doPick(point, false, retVec);
+            }
+        }
+    }
+
+    public void pickElement(Rectangle2D pickArea, AffineTransform ltw, boolean boundingBox,
+                            List<List<SVGElement>> retVec, RenderableElement element) throws SVGException
+    {
+        if (boundingBox)
+        {
+            element.doPick(pickArea, ltw,true, retVec);
+        } else
+        {
+            // TODO: Properly handle rotation and shear transforms.
+            //       This works fine for translation and scale though.
+            Rectangle pickRect = pickArea.getBounds();
+            pickRect.x -= ltw.getTranslateX();
+            pickRect.y -= ltw.getTranslateY();
+            BufferedImage img = paintToBuffer(null, ltw.getScaleX(), ltw.getScaleY(), pickRect,
+                                              this, Color.BLACK, true);
+            Raster raster = img.getRaster();
+            int x = raster.getMinX();
+            int w = raster.getWidth();
+            int y = raster.getMinY();
+            int h = raster.getHeight();
+            int[] srcPix = raster.getPixels(x, y, w, h, (int[]) null);
+            boolean hasVisiblePixel = false;
+            for (int i = 0; i < srcPix.length; i += 4)
+            {
+                int sr = srcPix[i];
+                int sg = srcPix[i + 1];
+                int sb = srcPix[i + 2];
+                if (luminanceToAlpha(sr, sg, sb) > 0)
+                {
+                    hasVisiblePixel = true;
+                    break;
+                }
+            }
+            // Pick if any pixel in the pick area is visible.
+            if (hasVisiblePixel)
+            {
+                element.doPick(pickArea, ltw, false, retVec);
+            }
+        }
+    }
+
+    private static double luminanceToAlpha(int rgb)
+    {
+        return luminanceToAlpha((rgb >> 16) & 0xFF, (rgb >> 8) & 0xFF, rgb & 0xFF);
+    }
+
+    private static double luminanceToAlpha(int r, int g, int b)
+    {
+        // Assuming 'linearRGB' as the 'color-interpolation' value of the mask.
+        return 0.2125 * r + 0.7154 * g + 0.0721 * b;
+    }
+
+    private static class MaskComposite implements Composite, CompositeContext
+    {
+
+        @Override
+        public CompositeContext createContext(ColorModel srcColorModel,
+                                              ColorModel dstColorModel, RenderingHints hints)
+        {
+            return this;
+        }
+
+        @Override
+        public void dispose()
+        {
+        }
+
+        public void composeRGB(int[] src, int[] dst)
+        {
+            int w = src.length;
+
+            for (int i = 0; i < w; i += 4)
+            {
+                int sr = src[i];
+                int sg = src[i + 1];
+                int sb = src[i + 2];
+                int da = dst[i + 3];
+                double luminance = luminanceToAlpha(sr, sg, sb) / 255d;
+                da *= luminance;
+                dst[i + 3] = Math.min(255, Math.max(0, da));
+            }
+        }
+
+        @Override
+        public void compose(Raster src, Raster dstIn, WritableRaster dstOut) {
+            assert dstIn == dstOut;
+            assert src.getNumBands() == dstIn.getNumBands();
+
+            int x = dstOut.getMinX();
+            int w = dstOut.getWidth();
+            int y = dstOut.getMinY();
+            int h = dstOut.getHeight();
+            int[] srcPix = src.getPixels(x, y, w, h, (int[]) null);
+            int[] dstPix = dstIn.getPixels(x, y, w, h, (int[]) null);
+            composeRGB(srcPix, dstPix);
+            dstOut.setPixels(x, y, w, h, dstPix);
+        }
+    }
+}

--- a/svg-core/src/main/java/com/kitfox/svg/MissingGlyph.java
+++ b/svg-core/src/main/java/com/kitfox/svg/MissingGlyph.java
@@ -156,7 +156,7 @@ public class MissingGlyph extends ShapeElement
     }
 
     @Override
-    public void render(Graphics2D g) throws SVGException
+    protected void doRender(Graphics2D g) throws SVGException
     {
         //Do not push or pop stack
 

--- a/svg-core/src/main/java/com/kitfox/svg/Path.java
+++ b/svg-core/src/main/java/com/kitfox/svg/Path.java
@@ -88,7 +88,7 @@ public class Path extends ShapeElement
     }
 
     @Override
-    public void render(Graphics2D g) throws SVGException
+    protected void doRender(Graphics2D g) throws SVGException
     {
         beginLayer(g);
         renderShape(g, path);

--- a/svg-core/src/main/java/com/kitfox/svg/Polygon.java
+++ b/svg-core/src/main/java/com/kitfox/svg/Polygon.java
@@ -99,7 +99,7 @@ public class Polygon extends ShapeElement
     }
 
     @Override
-    public void render(Graphics2D g) throws SVGException
+    protected void doRender(Graphics2D g) throws SVGException
     {
         beginLayer(g);
         renderShape(g, path);

--- a/svg-core/src/main/java/com/kitfox/svg/Polyline.java
+++ b/svg-core/src/main/java/com/kitfox/svg/Polyline.java
@@ -98,7 +98,7 @@ public class Polyline extends ShapeElement
     }
 
     @Override
-    public void render(Graphics2D g) throws SVGException
+    protected void doRender(Graphics2D g) throws SVGException
     {
         beginLayer(g);
         renderShape(g, path);

--- a/svg-core/src/main/java/com/kitfox/svg/Rect.java
+++ b/svg-core/src/main/java/com/kitfox/svg/Rect.java
@@ -202,7 +202,7 @@ public class Rect extends ShapeElement
     }
 
     @Override
-    public void render(Graphics2D g) throws SVGException
+    protected void doRender(Graphics2D g) throws SVGException
     {
         beginLayer(g);
         renderShape(g, rect);

--- a/svg-core/src/main/java/com/kitfox/svg/RenderableElement.java
+++ b/svg-core/src/main/java/com/kitfox/svg/RenderableElement.java
@@ -55,6 +55,7 @@ abstract public class RenderableElement extends TransformableElement
 {
     AffineTransform cachedXform = null;
 
+    Mask cachedMask;
     Shape cachedClip = null;
     public static final int VECTOR_EFFECT_NONE = 0;
     public static final int VECTOR_EFFECT_NON_SCALING_STROKE = 1;
@@ -92,23 +93,23 @@ abstract public class RenderableElement extends TransformableElement
         {
             vectorEffect = VECTOR_EFFECT_NONE;
         }
+
+        cachedMask = getMask(sty);
     }
 
     public void render(Graphics2D g) throws SVGException
     {
-        Mask mask = getMask();
-        if (mask != null)
+        if (cachedMask != null)
         {
-            mask.renderElement(g, this);
+            cachedMask.renderElement(g, this);
         } else
         {
             doRender(g);
         }
     }
 
-    private Mask getMask() throws SVGException
+    private Mask getMask(StyleAttribute styleAttrib) throws SVGException
     {
-        StyleAttribute styleAttrib = new StyleAttribute();
         if (getStyle(styleAttrib.setName("mask"), false)
             && !"none".equals(styleAttrib.getStringValue())) {
             URI uri = styleAttrib.getURIValue(getXMLBase());
@@ -124,10 +125,9 @@ abstract public class RenderableElement extends TransformableElement
 
     void pick(Point2D point, boolean boundingBox, List<List<SVGElement>> retVec) throws SVGException
     {
-        Mask mask = getMask();
-        if (mask != null)
+        if (cachedMask != null)
         {
-            mask.pickElement(point, boundingBox, retVec, this);
+            cachedMask.pickElement(point, boundingBox, retVec, this);
         } else
         {
             doPick(point, boundingBox, retVec);
@@ -138,10 +138,9 @@ abstract public class RenderableElement extends TransformableElement
 
     void pick(Rectangle2D pickArea, AffineTransform ltw, boolean boundingBox, List<List<SVGElement>> retVec) throws SVGException
     {
-        Mask mask = getMask();
-        if (mask != null)
+        if (cachedMask != null)
         {
-            mask.pickElement(pickArea, ltw, boundingBox, retVec, this);
+            cachedMask.pickElement(pickArea, ltw, boundingBox, retVec, this);
         } else
         {
             doPick(pickArea, ltw, boundingBox, retVec);

--- a/svg-core/src/main/java/com/kitfox/svg/RenderableElement.java
+++ b/svg-core/src/main/java/com/kitfox/svg/RenderableElement.java
@@ -3,16 +3,16 @@
  * Copyright (c) 2004, Mark McKay
  * All rights reserved.
  *
- * Redistribution and use in source and binary forms, with or 
+ * Redistribution and use in source and binary forms, with or
  * without modification, are permitted provided that the following
  * conditions are met:
  *
- *   - Redistributions of source code must retain the above 
+ *   - Redistributions of source code must retain the above
  *     copyright notice, this list of conditions and the following
  *     disclaimer.
  *   - Redistributions in binary form must reproduce the above
  *     copyright notice, this list of conditions and the following
- *     disclaimer in the documentation and/or other materials 
+ *     disclaimer in the documentation and/or other materials
  *     provided with the distribution.
  *
  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
@@ -26,8 +26,8 @@
  * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
  * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
  * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
- * OF THE POSSIBILITY OF SUCH DAMAGE. 
- * 
+ * OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
  * Mark McKay can be contacted at mark@kitfox.com.  Salamander and other
  * projects can be found at http://www.kitfox.com
  *
@@ -54,7 +54,7 @@ import java.util.List;
 abstract public class RenderableElement extends TransformableElement
 {
     AffineTransform cachedXform = null;
-    
+
     Shape cachedClip = null;
     public static final int VECTOR_EFFECT_NONE = 0;
     public static final int VECTOR_EFFECT_NON_SCALING_STROKE = 1;
@@ -96,14 +96,59 @@ abstract public class RenderableElement extends TransformableElement
 
     public void render(Graphics2D g) throws SVGException
     {
-        doRender(g);
+        Mask mask = getMask();
+        if (mask != null)
+        {
+            mask.renderElement(g, this);
+        } else
+        {
+            doRender(g);
+        }
+    }
+
+    private Mask getMask() throws SVGException
+    {
+        StyleAttribute styleAttrib = new StyleAttribute();
+        if (getStyle(styleAttrib.setName("mask"), false)
+            && !"none".equals(styleAttrib.getStringValue())) {
+            URI uri = styleAttrib.getURIValue(getXMLBase());
+            if (uri == null) {
+                return null;
+            }
+            return  (Mask) diagram.getUniverse().getElement(uri);
+        }
+        return null;
     }
 
     abstract protected void doRender(Graphics2D g) throws SVGException;
 
-    abstract void pick(Point2D point, boolean boundingBox, List<List<SVGElement>> retVec) throws SVGException;
+    void pick(Point2D point, boolean boundingBox, List<List<SVGElement>> retVec) throws SVGException
+    {
+        Mask mask = getMask();
+        if (mask != null)
+        {
+            mask.pickElement(point, boundingBox, retVec, this);
+        } else
+        {
+            doPick(point, boundingBox, retVec);
+        }
+    }
 
-    abstract void pick(Rectangle2D pickArea, AffineTransform ltw, boolean boundingBox, List<List<SVGElement>> retVec) throws SVGException;
+    protected abstract void doPick(Point2D point, boolean boundingBox, List<List<SVGElement>> retVec) throws SVGException;
+
+    void pick(Rectangle2D pickArea, AffineTransform ltw, boolean boundingBox, List<List<SVGElement>> retVec) throws SVGException
+    {
+        Mask mask = getMask();
+        if (mask != null)
+        {
+            mask.pickElement(pickArea, ltw, boundingBox, retVec, this);
+        } else
+        {
+            doPick(pickArea, ltw, boundingBox, retVec);
+        }
+    }
+
+    protected abstract void doPick(Rectangle2D pickArea, AffineTransform ltw, boolean boundingBox, List<List<SVGElement>> retVec) throws SVGException;
 
     abstract public Rectangle2D getBoundingBox() throws SVGException;
     /*
@@ -116,7 +161,7 @@ abstract public class RenderableElement extends TransformableElement
     /**
      * Pushes transform stack, transforms to local coordinates and sets up
      * clipping mask.
-     * 
+     *
      * @param g Graphics context
      * @throws com.kitfox.svg.SVGException
      */

--- a/svg-core/src/main/java/com/kitfox/svg/RenderableElement.java
+++ b/svg-core/src/main/java/com/kitfox/svg/RenderableElement.java
@@ -94,7 +94,12 @@ abstract public class RenderableElement extends TransformableElement
         }
     }
 
-    abstract public void render(Graphics2D g) throws SVGException;
+    public void render(Graphics2D g) throws SVGException
+    {
+        doRender(g);
+    }
+
+    abstract protected void doRender(Graphics2D g) throws SVGException;
 
     abstract void pick(Point2D point, boolean boundingBox, List<List<SVGElement>> retVec) throws SVGException;
 

--- a/svg-core/src/main/java/com/kitfox/svg/SVGLoader.java
+++ b/svg-core/src/main/java/com/kitfox/svg/SVGLoader.java
@@ -111,6 +111,7 @@ public class SVGLoader extends DefaultHandler
         nodeClasses.put("line", Line.class);
         nodeClasses.put("lineargradient", LinearGradient.class);
         nodeClasses.put("marker", Marker.class);
+        nodeClasses.put("mask", Mask.class);
         nodeClasses.put("metadata", Metadata.class);
         nodeClasses.put("missing-glyph", MissingGlyph.class);
         nodeClasses.put("path", Path.class);

--- a/svg-core/src/main/java/com/kitfox/svg/SVGRoot.java
+++ b/svg-core/src/main/java/com/kitfox/svg/SVGRoot.java
@@ -329,7 +329,7 @@ public class SVGRoot extends Group
     }
     
     @Override
-    public void pick(Rectangle2D pickArea, AffineTransform ltw, boolean boundingBox, List<List<SVGElement>> retVec) throws SVGException
+    public void doPick(Rectangle2D pickArea, AffineTransform ltw, boolean boundingBox, List<List<SVGElement>> retVec) throws SVGException
     {
         if (viewXform != null)
         {
@@ -337,11 +337,11 @@ public class SVGRoot extends Group
             ltw.concatenate(viewXform);
         }
         
-        super.pick(pickArea, ltw, boundingBox, retVec);
+        super.doPick(pickArea, ltw, boundingBox, retVec);
     }
     
     @Override
-    public void pick(Point2D point, boolean boundingBox, List<List<SVGElement>> retVec) throws SVGException
+    public void doPick(Point2D point, boolean boundingBox, List<List<SVGElement>> retVec) throws SVGException
     {
         Point2D xPoint = new Point2D.Double(point.getX(), point.getY());
         if (viewXform != null)
@@ -355,7 +355,7 @@ public class SVGRoot extends Group
             }
         }
         
-        super.pick(xPoint, boundingBox, retVec);
+        super.doPick(xPoint, boundingBox, retVec);
     }
 
     @Override

--- a/svg-core/src/main/java/com/kitfox/svg/SVGRoot.java
+++ b/svg-core/src/main/java/com/kitfox/svg/SVGRoot.java
@@ -251,7 +251,7 @@ public class SVGRoot extends Group
     }
 
     @Override
-    public void render(Graphics2D g) throws SVGException
+    protected void doRender(Graphics2D g) throws SVGException
     {
         prepareViewport();
         
@@ -303,7 +303,7 @@ public class SVGRoot extends Group
         AffineTransform cachedXform = g.getTransform();
         g.transform(viewXform);
         
-        super.render(g);
+        super.doRender(g);
         
         g.setTransform(cachedXform);
     }

--- a/svg-core/src/main/java/com/kitfox/svg/ShapeElement.java
+++ b/svg-core/src/main/java/com/kitfox/svg/ShapeElement.java
@@ -76,7 +76,7 @@ abstract public class ShapeElement extends RenderableElement
     }
 
     @Override
-    abstract public void render(java.awt.Graphics2D g) throws SVGException;
+    abstract protected void doRender(java.awt.Graphics2D g) throws SVGException;
 
     /*
     protected void setStrokeWidthScalar(float strokeWidthScalar)

--- a/svg-core/src/main/java/com/kitfox/svg/ShapeElement.java
+++ b/svg-core/src/main/java/com/kitfox/svg/ShapeElement.java
@@ -86,7 +86,7 @@ abstract public class ShapeElement extends RenderableElement
      */
 
     @Override
-    void pick(Point2D point, boolean boundingBox, List<List<SVGElement>> retVec) throws SVGException
+    protected void doPick(Point2D point, boolean boundingBox, List<List<SVGElement>> retVec) throws SVGException
     {
 //        StyleAttribute styleAttrib = new StyleAttribute();
 //        if (getStyle(styleAttrib.setName("fill")) && getShape().contains(point))
@@ -97,7 +97,7 @@ abstract public class ShapeElement extends RenderableElement
     }
 
     @Override
-    void pick(Rectangle2D pickArea, AffineTransform ltw, boolean boundingBox, List<List<SVGElement>> retVec) throws SVGException
+    protected void doPick(Rectangle2D pickArea, AffineTransform ltw, boolean boundingBox, List<List<SVGElement>> retVec) throws SVGException
     {
 //        StyleAttribute styleAttrib = new StyleAttribute();
 //        if (getStyle(styleAttrib.setName("fill")) && getShape().contains(point))

--- a/svg-core/src/main/java/com/kitfox/svg/Symbol.java
+++ b/svg-core/src/main/java/com/kitfox/svg/Symbol.java
@@ -111,12 +111,12 @@ public class Symbol extends Group
     }
 
     @Override
-    public void render(Graphics2D g) throws SVGException
+    protected void doRender(Graphics2D g) throws SVGException
     {
         AffineTransform oldXform = g.getTransform();
         g.transform(viewXform);
 
-        super.render(g);
+        super.doRender(g);
 
         g.setTransform(oldXform);
     }

--- a/svg-core/src/main/java/com/kitfox/svg/Text.java
+++ b/svg-core/src/main/java/com/kitfox/svg/Text.java
@@ -451,7 +451,7 @@ public class Text extends ShapeElement
 //    }
 
     @Override
-    public void render(Graphics2D g) throws SVGException
+    protected void doRender(Graphics2D g) throws SVGException
     {
         beginLayer(g);
         renderShape(g, textShape);

--- a/svg-core/src/main/java/com/kitfox/svg/Tspan.java
+++ b/svg-core/src/main/java/com/kitfox/svg/Tspan.java
@@ -299,7 +299,7 @@ public class Tspan extends ShapeElement
 //    }
 
     @Override
-    public void render(Graphics2D g) throws SVGException
+    protected void doRender(Graphics2D g) throws SVGException
     {
         float cursorX = 0;
         float cursorY = 0;

--- a/svg-core/src/main/java/com/kitfox/svg/Use.java
+++ b/svg-core/src/main/java/com/kitfox/svg/Use.java
@@ -111,7 +111,7 @@ public class Use extends ShapeElement
     }
 
     @Override
-    public void render(Graphics2D g) throws SVGException
+    protected void doRender(Graphics2D g) throws SVGException
     {
         beginLayer(g);
 


### PR DESCRIPTION
This is a somewhat rudimentary implementation of masks. Most likely it can be done in a more efficient manner, but compared to no support for masks at all this is probably still better.

I have tested the implementation using the examples from https://github.com/blackears/svgSalamander/issues/66.
However there might still be some edge cases which aren't properly handled and it certainly isn't a spec compliant implementation.
For example it is always assumed that the `color-interpolation` attribute is `linearRGB` and `masUnits` are ignored.

For the picking mechanism I had to make some trade-offs:
- If `boundingBox` is specified then the mask is ignored. I am not sure how the mask would interact in this mode so I decided that it simply shouldn't count.
- If a pick area is given then the mask will only block the picking operation if there isn't at least one pixel that is partially visible. This might lead to some unexpected results where an element clips the masking area where the element isn't shown, but the mask doesn't fully hide the picking area, hence the element gets included in the pick result. (these are probably rather niche cases)
- Also for picking areas if the given `AffineTransform` has a rotational or shear component then the picking result will most likely be incorrect.

Nonetheless the current state of picking works as expected with the examples from the issue.