### PR TITLE
Properly implement <tspan>

### DIFF
--- a/svg-core/src/main/java/com/kitfox/svg/Mask.java
+++ b/svg-core/src/main/java/com/kitfox/svg/Mask.java
@@ -30,8 +30,6 @@
  *
  * Mark McKay can be contacted at mark@kitfox.com.  Salamander and other
  * projects can be found at http://www.kitfox.com
- *
- * Created on January 26, 2004, 1:56 AM
  */
 package com.kitfox.svg;
 

--- a/svg-core/src/main/java/com/kitfox/svg/Text.java
+++ b/svg-core/src/main/java/com/kitfox/svg/Text.java
@@ -35,46 +35,28 @@
  */
 package com.kitfox.svg;
 
-import com.kitfox.svg.util.FontSystem;
+import com.kitfox.svg.util.FontUtil;
 import com.kitfox.svg.xml.StyleAttribute;
-import java.awt.Graphics2D;
-import java.awt.Shape;
+
 import java.awt.geom.AffineTransform;
-import java.awt.geom.GeneralPath;
-import java.awt.geom.Point2D;
-import java.awt.geom.Rectangle2D;
-import java.io.Serializable;
-import java.util.LinkedList;
+import java.awt.geom.Path2D;
+import java.util.Arrays;
 import java.util.List;
-import java.util.logging.Level;
-import java.util.logging.Logger;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
 
 /**
  * @author Mark McKay
  * @author <a href="mailto:mark@kitfox.com">Mark McKay</a>
  */
-public class Text extends ShapeElement
+public class Text extends Tspan
 {
     public static final String TAG_NAME = "text";
     
-    float x = 0;
-    float y = 0;
-    AffineTransform transform = null;
-    String fontFamily;
-    float fontSize;
-    //List of strings and tspans containing the content of this node
-    LinkedList<Serializable> content = new LinkedList<Serializable>();
-    Shape textShape;
     public static final int TXAN_START = 0;
     public static final int TXAN_MIDDLE = 1;
     public static final int TXAN_END = 2;
-    int textAnchor = TXAN_START;
     public static final int TXST_NORMAL = 0;
     public static final int TXST_ITALIC = 1;
     public static final int TXST_OBLIQUE = 2;
-    int fontStyle;
     public static final int TXWE_NORMAL = 0;
     public static final int TXWE_BOLD = 1;
     public static final int TXWE_BOLDER = 2;
@@ -88,11 +70,9 @@ public class Text extends ShapeElement
     public static final int TXWE_700 = 10;
     public static final int TXWE_800 = 11;
     public static final int TXWE_900 = 12;
-    int fontWeight;
 
-    float textLength = -1;
-    String lengthAdjust = "spacing";
-    
+    int textAnchor = TXAN_START;
+
     /**
      * Creates a new instance of Stop
      */
@@ -107,25 +87,6 @@ public class Text extends ShapeElement
     }
 
     /**
-     * Removes all strings and Tspan elements that are children of this element.
-     */
-    public void clearContent()
-    {
-        content.clear();
-    }
-    
-    public void appendText(String text)
-    {
-        content.addLast(text);
-    }
-
-    public void appendTspan(Tspan tspan) throws SVGElementException
-    {
-        super.loaderAddChild(null, tspan);
-        content.addLast(tspan);
-    }
-
-    /**
      * Discard cached information
      */
     public void rebuild() throws SVGException
@@ -133,122 +94,15 @@ public class Text extends ShapeElement
         build();
     }
 
-    public List<Serializable> getContent()
-    {
-        return content;
-    }
-
-    /**
-     * Called after the start element but before the end element to indicate
-     * each child tag that has been processed
-     */
     @Override
-    public void loaderAddChild(SVGLoaderHelper helper, SVGElement child) throws SVGElementException
-    {
-        super.loaderAddChild(helper, child);
-
-        content.addLast(child);
-    }
-
-    /**
-     * Called during load process to add text scanned within a tag
-     */
-    @Override
-    public void loaderAddText(SVGLoaderHelper helper, String text)
-    {
-        Matcher matchWs = Pattern.compile("\\s*").matcher(text);
-        if (!matchWs.matches())
-        {
-            content.addLast(text);
-        }
-    }
-
-    @Override
-    public void build() throws SVGException
-    {
+    protected void build() throws SVGException {
         super.build();
+        buildText();
+    }
 
-        StyleAttribute sty = new StyleAttribute();
-
-        if (getPres(sty.setName("x")))
-        {
-            x = sty.getFloatValueWithUnits();
-        }
-
-        if (getPres(sty.setName("y")))
-        {
-            y = sty.getFloatValueWithUnits();
-        }
-
-        if (getStyle(sty.setName("font-family")))
-        {
-            fontFamily = sty.getStringValue();
-        }
-        else
-        {
-            fontFamily = "SansSerif";
-        }
-
-        if (getStyle(sty.setName("font-size")))
-        {
-            fontSize = sty.getFloatValueWithUnits();
-        }
-        else
-        {
-            fontSize = 12f;
-        }
-
-        if (getStyle(sty.setName("textLength")))
-        {
-            textLength = sty.getFloatValueWithUnits();
-        }
-        else
-        {
-            textLength = -1;
-        }
-
-        if (getStyle(sty.setName("lengthAdjust")))
-        {
-            lengthAdjust = sty.getStringValue();
-        }
-        else
-        {
-            lengthAdjust = "spacing";
-        }
-
-        if (getStyle(sty.setName("font-style")))
-        {
-            String s = sty.getStringValue();
-            if ("normal".equals(s))
-            {
-                fontStyle = TXST_NORMAL;
-            } else if ("italic".equals(s))
-            {
-                fontStyle = TXST_ITALIC;
-            } else if ("oblique".equals(s))
-            {
-                fontStyle = TXST_OBLIQUE;
-            }
-        } else
-        {
-            fontStyle = TXST_NORMAL;
-        }
-
-        if (getStyle(sty.setName("font-weight")))
-        {
-            String s = sty.getStringValue();
-            if ("normal".equals(s))
-            {
-                fontWeight = TXWE_NORMAL;
-            } else if ("bold".equals(s))
-            {
-                fontWeight = TXWE_BOLD;
-            }
-        } else
-        {
-            fontWeight = TXWE_NORMAL;
-        }
-
+    protected void buildAttributes(StyleAttribute sty) throws SVGException
+    {
+        super.buildAttributes(sty);
         if (getStyle(sty.setName("text-anchor")))
         {
             String s = sty.getStringValue();
@@ -266,208 +120,45 @@ public class Text extends ShapeElement
         {
             textAnchor = TXAN_START;
         }
-
-        //text anchor
-        //text-decoration
-        //text-rendering
-
-        buildText();
     }
 
-    protected void buildText() throws SVGException
+
+    private void buildText() throws SVGException
     {
-        //Get font
-        String[] families = fontFamily.split(",");
-        Font font = null;
-        for (int i = 0; i < families.length; ++i)
-        {
-            font = diagram.getUniverse().getFont(families[i]);
-            if (font != null)
-            {
-                break;
-            }
-        }
-        
-        if (font == null)
-        {
-            //Check system fonts
-            font = FontSystem.createFont(fontFamily, fontStyle, fontWeight, fontSize);
-        }
+        super.buildTextShape(null);
+        alignSegmentsAtAnchor(fullPath);
+    }
 
-        if (font == null)
-        {
-            Logger.getLogger(Text.class.getName()).log(Level.WARNING, "Could not create font " + fontFamily);
-            font = FontSystem.createFont("Serif", fontStyle, fontWeight, fontSize);
-        }
-        
-        GeneralPath textPath = new GeneralPath();
-        textShape = textPath;
-
-        float cursorX = x, cursorY = y;
-        
-        
-        AffineTransform xform = new AffineTransform();
-
-        for (Serializable obj : content) {
-            if (obj instanceof String)
-            {
-                String text = (String) obj;
-                if (text != null)
-                {
-                    text = text.trim();
-                }
-
-                for (int i = 0; i < text.length(); i++)
-                {
-                    xform.setToIdentity();
-                    xform.setToTranslation(cursorX, cursorY);
-
-                    String unicode = text.substring(i, i + 1);
-                    MissingGlyph glyph = font.getGlyph(unicode);
-
-                    Shape path = glyph.getPath();
-                    if (path != null)
-                    {
-                        path = xform.createTransformedShape(path);
-                        textPath.append(path, false);
-                    }
-
-                    cursorX += glyph.getHorizAdvX();
-                }
-
-                strokeWidthScalar = 1f;
-            }
-            else if (obj instanceof Tspan)
-            {
-                Tspan tspan = (Tspan)obj;
-                Point2D cursor = new Point2D.Float(cursorX, cursorY);
-                tspan.appendToShape(textPath, cursor);
-                cursorX = (float)cursor.getX();
-                cursorY = (float)cursor.getY();
-                
-            }
-
-        }
-
+    private void alignSegmentsAtAnchor(Path2D textPath)
+    {
         switch (textAnchor)
         {
             case TXAN_MIDDLE:
-            {
-                AffineTransform at = new AffineTransform();
-                at.translate(-textPath.getBounds().getWidth() / 2, 0);
-                textPath.transform(at);
+                transformSegments(segments, AffineTransform.getTranslateInstance(
+                        -textPath.getBounds().getWidth() / 2, 0
+                ));
                 break;
-            }
             case TXAN_END:
-            {
-                AffineTransform at = new AffineTransform();
-                at.translate(-textPath.getBounds().getWidth(), 0);
-                textPath.transform(at);
+                transformSegments(segments, AffineTransform.getTranslateInstance(
+                        -textPath.getBounds().getWidth(), 0
+                ));
                 break;
-            }
+            default:
+                break;
         }
     }
 
-//    private void buildSysFont(java.awt.Font font) throws SVGException
-//    {
-//        GeneralPath textPath = new GeneralPath();
-//        textShape = textPath;
-//
-//        float cursorX = x, cursorY = y;
-//
-////        FontMetrics fm = g.getFontMetrics(font);
-//        FontRenderContext frc = new FontRenderContext(null, true, true);
-//
-////        FontFace fontFace = font.getFontFace();
-//        //int unitsPerEm = fontFace.getUnitsPerEm();
-////        int ascent = fm.getAscent();
-////        float fontScale = fontSize / (float)ascent;
-//
-////        AffineTransform oldXform = g.getTransform();
-//        AffineTransform xform = new AffineTransform();
-//
-//        for (Iterator it = content.iterator(); it.hasNext();)
-//        {
-//            Object obj = it.next();
-//
-//            if (obj instanceof String)
-//            {
-//                String text = (String)obj;
-//                text = text.trim();
-//
-//                Shape textShape = font.createGlyphVector(frc, text).getOutline(cursorX, cursorY);
-//                textPath.append(textShape, false);
-////                renderShape(g, textShape);
-////                g.drawString(text, cursorX, cursorY);
-//
-//                Rectangle2D rect = font.getStringBounds(text, frc);
-//                cursorX += (float) rect.getWidth();
-//            } else if (obj instanceof Tspan)
-//            {
-//                /*
-//                 Tspan tspan = (Tspan)obj;
-//                 
-//                 xform.setToIdentity();
-//                 xform.setToTranslation(cursorX, cursorY);
-//                 
-//                 Shape tspanShape = tspan.getShape();
-//                 tspanShape = xform.createTransformedShape(tspanShape);
-//                 textArea.add(new Area(tspanShape));
-//                 
-//                 cursorX += tspanShape.getBounds2D().getWidth();
-//                 */
-//
-//
-//                Tspan tspan = (Tspan)obj;
-//                Point2D cursor = new Point2D.Float(cursorX, cursorY);
-////                tspan.setCursorX(cursorX);
-////                tspan.setCursorY(cursorY);
-//                tspan.appendToShape(textPath, cursor);
-////                cursorX = tspan.getCursorX();
-////                cursorY = tspan.getCursorY();
-//                cursorX = (float)cursor.getX();
-//                cursorY = (float)cursor.getY();
-//
-//            }
-//        }
-//
-//        switch (textAnchor)
-//        {
-//            case TXAN_MIDDLE:
-//            {
-//                AffineTransform at = new AffineTransform();
-//                at.translate(-textPath.getBounds().getWidth() / 2, 0);
-//                textPath.transform(at);
-//                break;
-//            }
-//            case TXAN_END:
-//            {
-//                AffineTransform at = new AffineTransform();
-//                at.translate(-Math.ceil(textPath.getBounds().getWidth()), 0);
-//                textPath.transform(at);
-//                break;
-//            }
-//        }
-//    }
-
-    @Override
-    protected void doRender(Graphics2D g) throws SVGException
+    private void transformSegments(List<TextSegment> segments, AffineTransform transform)
     {
-        beginLayer(g);
-        renderShape(g, textShape);
-        finishLayer(g);
-    }
-
-    @Override
-    public Shape getShape()
-    {
-        return shapeToParent(textShape);
-    }
-
-    @Override
-    public Rectangle2D getBoundingBox() throws SVGException
-    {
-        return boundsToParent(includeStrokeInBounds(textShape.getBounds2D()));
+        for (TextSegment segment : segments) {
+            if (segment.textPath != null)
+            {
+                segment.textPath.transform(transform);
+            } else
+            {
+                transformSegments(segment.element.segments, transform);
+            }
+        }
     }
 
     /**
@@ -478,118 +169,26 @@ public class Text extends ShapeElement
      * update
      */
     @Override
-    public boolean updateTime(double curTime) throws SVGException
-    {
-//        if (trackManager.getNumTracks() == 0) return false;
+    public boolean updateTime(double curTime) throws SVGException {
         boolean changeState = super.updateTime(curTime);
 
         //Get current values for parameters
-        StyleAttribute sty = new StyleAttribute();
-        boolean shapeChange = false;
+        FontUtil.FontInfo fontInfoOld = fontInfo;
+        float[] xOld = x;
+        float[] yOld = y;
+        float[] dxOld = dx;
+        float[] dyOld = dy;
+        buildShapeInformation();
 
-        if (getPres(sty.setName("x")))
-        {
-            float newVal = sty.getFloatValueWithUnits();
-            if (newVal != x)
-            {
-                x = newVal;
-                shapeChange = true;
-            }
-        }
-
-        if (getPres(sty.setName("y")))
-        {
-            float newVal = sty.getFloatValueWithUnits();
-            if (newVal != y)
-            {
-                y = newVal;
-                shapeChange = true;
-            }
-        }
-
-        if (getStyle(sty.setName("textLength")))
-        {
-            textLength = sty.getFloatValueWithUnits();
-        }
-        else
-        {
-            textLength = -1;
-        }
-
-        if (getStyle(sty.setName("lengthAdjust")))
-        {
-            lengthAdjust = sty.getStringValue();
-        }
-        else
-        {
-            lengthAdjust = "spacing";
-        }
-
-        if (getPres(sty.setName("font-family")))
-        {
-            String newVal = sty.getStringValue();
-            if (!newVal.equals(fontFamily))
-            {
-                fontFamily = newVal;
-                shapeChange = true;
-            }
-        }
-
-        if (getPres(sty.setName("font-size")))
-        {
-            float newVal = sty.getFloatValueWithUnits();
-            if (newVal != fontSize)
-            {
-                fontSize = newVal;
-                shapeChange = true;
-            }
-        }
-
-
-        if (getStyle(sty.setName("font-style")))
-        {
-            String s = sty.getStringValue();
-            int newVal = fontStyle;
-            if ("normal".equals(s))
-            {
-                newVal = TXST_NORMAL;
-            } else if ("italic".equals(s))
-            {
-                newVal = TXST_ITALIC;
-            } else if ("oblique".equals(s))
-            {
-                newVal = TXST_OBLIQUE;
-            }
-            if (newVal != fontStyle)
-            {
-                fontStyle = newVal;
-                shapeChange = true;
-            }
-        }
-
-        if (getStyle(sty.setName("font-weight")))
-        {
-            String s = sty.getStringValue();
-            int newVal = fontWeight;
-            if ("normal".equals(s))
-            {
-                newVal = TXWE_NORMAL;
-            } else if ("bold".equals(s))
-            {
-                newVal = TXWE_BOLD;
-            }
-            if (newVal != fontWeight)
-            {
-                fontWeight = newVal;
-                shapeChange = true;
-            }
-        }
+        boolean shapeChange = !fontInfo.equals(fontInfoOld)
+                              || !Arrays.equals(xOld, x)
+                              || !Arrays.equals(yOld, y)
+                              || !Arrays.equals(dxOld, dx)
+                              || !Arrays.equals(dyOld, dy);
 
         if (shapeChange)
         {
-            build();
-//            buildFont();
-//            return true;
+            buildText();
         }
 
         return changeState || shapeChange;

--- a/svg-core/src/main/java/com/kitfox/svg/Tspan.java
+++ b/svg-core/src/main/java/com/kitfox/svg/Tspan.java
@@ -202,11 +202,6 @@ public class Tspan extends ShapeElement
 
         fullPath = new GeneralPath();
 
-        if (cursor == null) {
-            cursor = new Cursor(getXCursorForIndex(0, 0),
-                                getYCursorForIndex(0, 0));
-        }
-
         segments.clear();
         segments.ensureCapacity(content.size());
         int currentCursorOffset = cursor.offset;
@@ -275,6 +270,12 @@ public class Tspan extends ShapeElement
 
         strokeWidthScalar = 1f;
         return textPath;
+    }
+
+    protected Cursor createInitialCursor()
+    {
+        return new Cursor(getXCursorForIndex(0, 0),
+                          getYCursorForIndex(0, 0));
     }
 
     private float getXCursorForIndex(float current, int index)

--- a/svg-core/src/main/java/com/kitfox/svg/util/FontSystem.java
+++ b/svg-core/src/main/java/com/kitfox/svg/util/FontSystem.java
@@ -45,6 +45,8 @@ import java.awt.GraphicsEnvironment;
 import java.awt.font.FontRenderContext;
 import java.awt.font.GlyphMetrics;
 import java.awt.font.GlyphVector;
+import java.awt.font.LineMetrics;
+import java.util.Arrays;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Locale;
@@ -136,13 +138,13 @@ public class FontSystem extends Font
         
         sysFont = new java.awt.Font(fontFamily, style | weight, 1).deriveFont(fontSize);
         
-        Canvas c = new Canvas();
-        fm = c.getFontMetrics(sysFont);
-        
+        FontRenderContext fontRenderContext = new FontRenderContext(null, true, true);
+        LineMetrics lineMetrics = sysFont.getLineMetrics("M", fontRenderContext);
+
         FontFace face = new FontFace();
-        face.setAscent(fm.getAscent());
-        face.setDescent(fm.getDescent());
-        face.setUnitsPerEm(fm.charWidth('M'));
+        face.setAscent((int) lineMetrics.getAscent());
+        face.setDescent((int) lineMetrics.getDescent());
+        face.setUnitsPerEm((int) sysFont.getStringBounds("M", fontRenderContext).getWidth());
         setFontFace(face);
     }
 

--- a/svg-core/src/main/java/com/kitfox/svg/util/FontSystem.java
+++ b/svg-core/src/main/java/com/kitfox/svg/util/FontSystem.java
@@ -73,11 +73,10 @@ public class FontSystem extends Font
         
         return sysFontNames.contains(fontName);
     }
-    
-    public static FontSystem createFont(String fontFamily, int fontStyle, int fontWeight, float fontSize)
+
+    public static FontSystem createFont(String[] fontFamilies, int fontStyle, int fontWeight, float fontSize)
     {
-        String[] families = fontFamily.split(",");
-        for (String fontName: families)
+        for (String fontName: fontFamilies)
         {
             String javaFontName = mapJavaFontName(fontName);
             if (checkIfSystemFontExists(javaFontName))
@@ -85,7 +84,7 @@ public class FontSystem extends Font
                 return new FontSystem(javaFontName, fontStyle, fontWeight, fontSize);
             }
         }
-        
+
         return null;
     }
 
@@ -130,7 +129,7 @@ public class FontSystem extends Font
                 weight = java.awt.Font.PLAIN;
                 break;
         }
-        
+
         sysFont = new java.awt.Font(fontFamily, style | weight, 1).deriveFont(fontSize);
         
         FontRenderContext fontRenderContext = new FontRenderContext(null, true, true);
@@ -163,7 +162,7 @@ public class FontSystem extends Font
             
             glyphCache.put(unicode, glyph);
         }
-        
+
         return glyph;
     }
     

--- a/svg-core/src/main/java/com/kitfox/svg/util/FontSystem.java
+++ b/svg-core/src/main/java/com/kitfox/svg/util/FontSystem.java
@@ -39,19 +39,15 @@ import com.kitfox.svg.Font;
 import com.kitfox.svg.FontFace;
 import com.kitfox.svg.Glyph;
 import com.kitfox.svg.MissingGlyph;
-import java.awt.Canvas;
-import java.awt.FontMetrics;
+
 import java.awt.GraphicsEnvironment;
 import java.awt.font.FontRenderContext;
 import java.awt.font.GlyphMetrics;
 import java.awt.font.GlyphVector;
 import java.awt.font.LineMetrics;
-import java.util.Arrays;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Locale;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
 
 /**
  *
@@ -60,11 +56,10 @@ import java.util.regex.Pattern;
 public class FontSystem extends Font
 {
     java.awt.Font sysFont;
-    FontMetrics fm;
 
-    HashMap<String, Glyph> glyphCache = new HashMap<String, Glyph>();
+    HashMap<String, Glyph> glyphCache = new HashMap<>();
     
-    static HashSet<String> sysFontNames = new HashSet<String>();
+    static HashSet<String> sysFontNames = new HashSet<>();
     
     public static boolean checkIfSystemFontExists(String fontName)
     {

--- a/svg-core/src/main/java/com/kitfox/svg/util/FontUtil.java
+++ b/svg-core/src/main/java/com/kitfox/svg/util/FontUtil.java
@@ -1,0 +1,181 @@
+/*
+ * SVG Salamander
+ * Copyright (c) 2004, Mark McKay
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or
+ * without modification, are permitted provided that the following
+ * conditions are met:
+ *
+ *   - Redistributions of source code must retain the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer.
+ *   - Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/or other materials
+ *     provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ * INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+ * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+ * OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ * Mark McKay can be contacted at mark@kitfox.com.  Salamander and other
+ * projects can be found at http://www.kitfox.com
+ */
+package com.kitfox.svg.util;
+
+import com.kitfox.svg.Font;
+import com.kitfox.svg.SVGDiagram;
+import com.kitfox.svg.SVGElement;
+import com.kitfox.svg.SVGException;
+import com.kitfox.svg.Text;
+import com.kitfox.svg.xml.StyleAttribute;
+
+import java.util.Arrays;
+import java.util.Objects;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+/**
+ * Utility class for parsing font information of an {@link SVGElement}.
+ *
+ * @author Jannis Weis
+ */
+public final class FontUtil
+{
+
+    private static final String DEFAULT_FONT_FAMILY = "sans-serif";
+    private static final float DEFAULT_FONT_SIZE = 12f;
+    private static final int DEFAULT_LETTER_SPACING = 0;
+    private static final int DEFAULT_FONT_STYLE = Text.TXST_NORMAL;
+    private static final int DEFAULT_FONT_WEIGHT = Text.TXWE_NORMAL;
+
+    private FontUtil() {}
+
+    public final static class FontInfo {
+        public final String[] families;
+        public final float size;
+        public final int style;
+        public final int weight;
+        public final float letterSpacing;
+
+        public FontInfo(String[] families, float size, int style, int weight, float letterSpacing)
+        {
+            this.families = families;
+            this.size = size;
+            this.style = style;
+            this.weight = weight;
+            this.letterSpacing = letterSpacing;
+        }
+
+        @Override
+        public boolean equals(Object o)
+        {
+            if (this == o) return true;
+            if (!(o instanceof FontInfo)) return false;
+            FontInfo fontInfo = (FontInfo) o;
+            return Float.compare(fontInfo.size, size) == 0
+                   && style == fontInfo.style && weight == fontInfo.weight
+                   && Float.compare(fontInfo.letterSpacing, letterSpacing) == 0
+                   && Arrays.equals(families, fontInfo.families);
+        }
+
+        @Override
+        public int hashCode()
+        {
+            int result = Objects.hash(size, style, weight, letterSpacing);
+            result = 31 * result + Arrays.hashCode(families);
+            return result;
+        }
+    }
+
+    public static FontInfo parseFontInfo(SVGElement element, StyleAttribute sty) throws SVGException
+    {
+        String fontFamily = DEFAULT_FONT_FAMILY;
+        if (element.getStyle(sty.setName("font-family")))
+        {
+            fontFamily = sty.getStringValue();
+        }
+
+        float fontSize = DEFAULT_FONT_SIZE;
+        if (element.getStyle(sty.setName("font-size")))
+        {
+            fontSize = sty.getFloatValueWithUnits();
+        }
+
+        float letterSpacing = DEFAULT_LETTER_SPACING;
+        if (element.getStyle(sty.setName("letter-spacing")))
+        {
+            letterSpacing = sty.getFloatValueWithUnits();
+        }
+
+        int fontStyle = DEFAULT_FONT_STYLE;
+        if (element.getStyle(sty.setName("font-style")))
+        {
+            String s = sty.getStringValue();
+            if ("normal".equals(s))
+            {
+                fontStyle = Text.TXST_NORMAL;
+            } else if ("italic".equals(s))
+            {
+                fontStyle = Text.TXST_ITALIC;
+            } else if ("oblique".equals(s))
+            {
+                fontStyle = Text.TXST_OBLIQUE;
+            }
+        }
+
+        int fontWeight = DEFAULT_FONT_WEIGHT;
+        if (element.getStyle(sty.setName("font-weight")))
+        {
+            String s = sty.getStringValue();
+            if ("normal".equals(s))
+            {
+                fontWeight = Text.TXWE_NORMAL;
+            } else if ("bold".equals(s))
+            {
+                fontWeight = Text.TXWE_BOLD;
+            }
+        }
+
+        return new FontInfo(fontFamily.split(","), fontSize, fontStyle, fontWeight, letterSpacing);
+    }
+
+    public static Font getFont(FontInfo info, SVGDiagram diagram)
+    {
+        return getFont(info.families, info.style, info.weight, info.size, diagram);
+    }
+
+    private static Font getFont(String[] families, int fontStyle, int fontWeight, float fontSize, SVGDiagram diagram)
+    {
+        Font font = null;
+        for (String family : families)
+        {
+            font = diagram.getUniverse().getFont(family);
+            if (font != null) break;
+        }
+        if (font == null)
+        {
+            //Check system fonts
+            font = FontSystem.createFont(families, fontStyle, fontWeight, fontSize);
+        }
+        if (font == null)
+        {
+            Logger.getLogger(FontSystem.class.getName())
+                    .log(Level.WARNING, "Could not create font " + Arrays.toString(families));
+            String[] defaultFont = new String[]{ FontUtil.DEFAULT_FONT_FAMILY };
+            font = FontSystem.createFont(defaultFont, fontStyle, fontWeight, fontSize);
+        }
+        return font;
+    }
+
+}

--- a/svg-core/src/main/java/com/kitfox/svg/xml/StyleAttribute.java
+++ b/svg-core/src/main/java/com/kitfox/svg/xml/StyleAttribute.java
@@ -154,6 +154,18 @@ public class StyleAttribute implements Serializable
         NumberWithUnits number = getNumberWithUnits();
         return convertUnitsToPixels(number.getUnits(), number.getValue());
     }
+
+    public float[] getFloatListWithUnits()
+    {
+        String[] values = getStringList();
+        float[] result = new float[values.length];
+        for (int i = 0; i < result.length; i++)
+        {
+            NumberWithUnits number = XMLParseUtil.parseNumberWithUnits(stringValue);
+            result[i] = convertUnitsToPixels(number.getUnits(), number.getValue());
+        }
+        return result;
+    }
     
     static public float convertUnitsToPixels(int unitType, float value)
     {


### PR DESCRIPTION
Seeing in #71 that `<tspan>` isn't properly implemented I have taken the liberty to do this.

Previously spans were using the attributes of the parent <text>
tag. They also couldn't be children of other <tspan> tags.

The <tspan> element now stores a list of text segments which are rendered in order to ensure correct z-ordering. 
This allows <tspan> elements to contain other spans itself. 
The <text> element now simply inherits from <tspan> and performs the additional transformation defined by 'text-anchor'.

The `Text` element should be API compatible with previous versions. Fot the `Tspan` tag however I wasn't sure how to deal with
the `setText` method. If there is no child <tspan> then it can behave as before and simply overwrite the contained text.
If child spans exists I'm not so sure what should happen. For now I have removed the method, though intend to add it back in
once it is clear how it should behave.