### PR TITLE
Implement rudimentary gaussian blur

### DIFF
--- a/svg-core/src/main/java/com/kitfox/svg/BufferPainter.java
+++ b/svg-core/src/main/java/com/kitfox/svg/BufferPainter.java
@@ -1,0 +1,167 @@
+package com.kitfox.svg;
+
+import java.awt.Color;
+import java.awt.Graphics2D;
+import java.awt.Rectangle;
+import java.awt.geom.AffineTransform;
+import java.awt.geom.Point2D;
+import java.awt.image.BufferedImage;
+import java.awt.image.ImageObserver;
+import java.util.Collections;
+import java.util.List;
+import java.util.Objects;
+import java.util.stream.Collectors;
+
+public class BufferPainter
+{
+    public static final boolean DEBUG_PAINT = false;
+
+    public static void paintElement(Graphics2D g, RenderableElement element) throws SVGException
+    {
+        if (element.cachedMask != null
+            || (element.filter != null && !element.filter.filterEffects.isEmpty()))
+        {
+            renderElement(g, element);
+        } else
+        {
+            element.doRender(g);
+        }
+    }
+
+    private static float getTransformScale(Point2D.Float origin, Point2D.Float testPoint,
+                                           AffineTransform transform)
+    {
+        transform.transform(testPoint, testPoint);
+        float dx = testPoint.x - origin.x;
+        float dy = testPoint.y - origin.y;
+        return (float) Math.sqrt(dx * dx + dy * dy);
+    }
+
+    private static void renderElement(Graphics2D g, RenderableElement element) throws SVGException
+    {
+        AffineTransform transform = g.getTransform();
+
+        Graphics2D gg = (Graphics2D) g.create();
+        Rectangle elementBounds = element.getBoundingBox().getBounds();
+        Rectangle transformedBounds = transform.createTransformedShape(elementBounds).getBounds();
+        Rectangle dstBounds = new Rectangle(transformedBounds);
+
+        BufferedImage elementImage = renderToBuffer(gg, element, transform, transformedBounds, dstBounds);
+
+        // Reset the transform. We already accounted for it in the buffer image.
+        gg.setTransform(new AffineTransform());
+        gg.drawImage(elementImage, dstBounds.x, dstBounds.y, null);
+        if (DEBUG_PAINT)
+        {
+            gg.setColor(Color.GREEN);
+            gg.drawRect(dstBounds.x, dstBounds.y, dstBounds.width, dstBounds.height);
+            if (!dstBounds.equals(transformedBounds))
+            {
+                gg.setColor(Color.PINK);
+                gg.drawRect(transformedBounds.x, transformedBounds.y, transformedBounds.width, transformedBounds.height);
+            }
+        }
+        gg.dispose();
+    }
+
+    private static BufferedImage renderToBuffer(Graphics2D gg, RenderableElement element,
+                                                AffineTransform transform, Rectangle transformedBounds,
+                                                Rectangle dstBounds) throws SVGException
+    {
+        Point2D.Float origin = new Point2D.Float(0, 0);
+        transform.transform(origin, origin);
+
+        // As filter operations are commonly implemented using convolutions they need to be
+        // aware of any possible scaling to compensate for it in their kernel size.
+        Point2D.Float testPoint = new Point2D.Float(1, 0);
+        float xScale = getTransformScale(origin, testPoint, transform);
+        testPoint.setLocation(0, 1);
+        float yScale = getTransformScale(origin, testPoint, transform);
+
+        List<FilterEffects.FilterOp> filterOps = element.filter == null
+                ? Collections.emptyList()
+                : element.filter.filterEffects.stream()
+                        .flatMap(f -> f.getOperations(dstBounds, xScale, yScale).stream())
+                        .filter(Objects::nonNull)
+                        .collect(Collectors.toList());
+
+        for (FilterEffects.FilterOp filterOp : filterOps)
+        {
+            int right = Math.max(dstBounds.x + dstBounds.width,
+                                 filterOp.requiredImageBounds.x + filterOp.requiredImageBounds.width);
+            int bottom = Math.max(dstBounds.y + dstBounds.height,
+                                  filterOp.requiredImageBounds.y + filterOp.requiredImageBounds.height);
+            dstBounds.x = Math.min(dstBounds.x, filterOp.requiredImageBounds.x);
+            dstBounds.y = Math.min(dstBounds.y, filterOp.requiredImageBounds.y);
+            dstBounds.width = right - dstBounds.x;
+            dstBounds.height = bottom - dstBounds.y;
+        }
+
+
+        BufferedImage elementImage = BufferPainter.paintToBuffer(gg, transform, dstBounds, transformedBounds,
+                                                                 element, null, true);
+
+        for (FilterEffects.FilterOp filterOp : filterOps)
+        {
+            elementImage = filterOp.op.filter(elementImage, null);
+        }
+
+        if (element.cachedMask != null)
+        {
+            // Draw the mask image. Implicitly the mask is empty i.e. has a completely black background.
+            // We can't draw the mask directly to the elementImage using the mask composite as
+            // masks may change the mask value a location at any time during mask realization.
+            BufferedImage maskImage = BufferPainter.paintToBuffer(gg, transform, dstBounds, transformedBounds,
+                                                                  element.cachedMask, Color.BLACK, false);
+
+            Graphics2D elementGraphics = (Graphics2D) elementImage.getGraphics();
+            elementGraphics.setRenderingHints(gg.getRenderingHints());
+            elementGraphics.setComposite(element.cachedMask.createMaskComposite());
+            elementGraphics.drawImage(maskImage, 0, 0, null);
+            elementGraphics.dispose();
+        }
+        return elementImage;
+    }
+
+    public static BufferedImage paintToBuffer(Graphics2D g, AffineTransform transform,
+                                              Rectangle srcBounds, RenderableElement element,
+                                              Color bgColor) throws SVGException
+    {
+        return paintToBuffer(g, transform, srcBounds, srcBounds, element, bgColor, false);
+    }
+
+    /*
+     * The srcBounds parameter is expected to be pre-transformed by the given transform.
+     */
+    public static BufferedImage paintToBuffer(Graphics2D g, AffineTransform transform,
+                                              Rectangle dstBounds, Rectangle srcBounds,
+                                              RenderableElement element,
+                                              Color bgColor, boolean preMultiplied) throws SVGException
+    {
+        int type = preMultiplied
+                ? BufferedImage.TYPE_INT_ARGB_PRE
+                : BufferedImage.TYPE_INT_ARGB;
+        BufferedImage img = new BufferedImage(dstBounds.width, dstBounds.height, type);
+        Graphics2D imgGraphics = (Graphics2D) img.getGraphics();
+        if (g != null)
+        {
+            imgGraphics.setRenderingHints(g.getRenderingHints());
+        } else if (bgColor != null)
+        {
+            imgGraphics.setColor(bgColor);
+            imgGraphics.fillRect(0, 0, img.getWidth(), img.getHeight());
+        }
+        int xRelative = srcBounds.x - dstBounds.x;
+        int yRelative = srcBounds.y - dstBounds.y;
+        imgGraphics.translate(xRelative, yRelative);
+        imgGraphics.clipRect(0, 0, srcBounds.width, srcBounds.height);
+
+        // Because we blit the image at the transformed location we have to compensate for the
+        // element location.
+        imgGraphics.translate(-srcBounds.x, -srcBounds.y);
+        imgGraphics.transform(transform);
+        element.doRender(imgGraphics);
+        imgGraphics.dispose();
+        return img;
+    }
+}

--- a/svg-core/src/main/java/com/kitfox/svg/BufferPainter.java
+++ b/svg-core/src/main/java/com/kitfox/svg/BufferPainter.java
@@ -46,11 +46,12 @@ public class BufferPainter
         Rectangle transformedBounds = transform.createTransformedShape(elementBounds).getBounds();
         Rectangle dstBounds = new Rectangle(transformedBounds);
 
+        ImageObserver observer = element.diagram.getCurrentRenderTarget();
         BufferedImage elementImage = renderToBuffer(gg, element, transform, transformedBounds, dstBounds);
 
         // Reset the transform. We already accounted for it in the buffer image.
         gg.setTransform(new AffineTransform());
-        gg.drawImage(elementImage, dstBounds.x, dstBounds.y, null);
+        gg.drawImage(elementImage, dstBounds.x, dstBounds.y, observer);
         if (DEBUG_PAINT)
         {
             gg.setColor(Color.GREEN);
@@ -117,7 +118,7 @@ public class BufferPainter
             Graphics2D elementGraphics = (Graphics2D) elementImage.getGraphics();
             elementGraphics.setRenderingHints(gg.getRenderingHints());
             elementGraphics.setComposite(element.cachedMask.createMaskComposite());
-            elementGraphics.drawImage(maskImage, 0, 0, null);
+            elementGraphics.drawImage(maskImage, 0, 0, element.diagram.getCurrentRenderTarget());
             elementGraphics.dispose();
         }
         return elementImage;

--- a/svg-core/src/main/java/com/kitfox/svg/FeGaussianBlur.java
+++ b/svg-core/src/main/java/com/kitfox/svg/FeGaussianBlur.java
@@ -1,0 +1,117 @@
+package com.kitfox.svg;
+
+import com.kitfox.svg.xml.StyleAttribute;
+
+import java.awt.Rectangle;
+import java.awt.image.ConvolveOp;
+import java.awt.image.Kernel;
+import java.util.Arrays;
+import java.util.List;
+
+public class FeGaussianBlur extends FilterEffects
+{
+    public static final String TAG_NAME = "fegaussianblur";
+
+    private float[] stdDeviation;
+    private float xCurrent;
+    private float yCurrent;
+    private ConvolveOp xBlur;
+    private ConvolveOp yBlur;
+
+    @Override
+    public String getTagName()
+    {
+        return TAG_NAME;
+    }
+
+    @Override
+    protected void build() throws SVGException
+    {
+        super.build();
+        StyleAttribute sty = new StyleAttribute();
+
+        stdDeviation = new float[]{0f};
+        if (getPres(sty.setName("stdDeviation")))
+        {
+            stdDeviation = sty.getFloatList();
+        }
+        xBlur = null;
+        yBlur = null;
+    }
+
+    @Override
+    public List<FilterOp> getOperations(Rectangle inputBounds, float xScale, float yScale)
+    {
+        float xSigma = xScale * stdDeviation[0];
+        float ySigma = yScale * stdDeviation[Math.min(stdDeviation.length - 1, 1)];
+
+        return Arrays.asList(
+                xSigma > 0
+                        ? getGaussianBlurFilter(inputBounds, xSigma, true)
+                        : null,
+                ySigma > 0
+                        ? getGaussianBlurFilter(inputBounds, ySigma, false)
+                        : null
+        );
+    }
+
+    public FilterOp getGaussianBlurFilter(Rectangle inputBounds, float sigma, boolean horizontal)
+    {
+        int multiplier = 2;
+        float radius = 2f * sigma + 1;
+        int size = (int) Math.ceil(radius * multiplier) + 1;
+        if (horizontal && (xBlur == null || xCurrent != sigma)
+            || !horizontal && (yBlur == null || yCurrent != sigma))
+        {
+            if (horizontal)
+            {
+                xCurrent = sigma;
+            } else
+            {
+                yCurrent = sigma;
+            }
+            float[] data = new float[size];
+
+            float radius2 = radius * radius;
+            float twoSigmaSquare = 2.0f * sigma * sigma;
+            float sigmaRoot = (float) Math.sqrt(twoSigmaSquare * Math.PI);
+            float total = 0.0f;
+
+            float middle = size / 2f;
+            for (int i = 0; i < size; i++)
+            {
+                float distance = middle - i;
+                distance *= distance;
+
+                data[i] = distance > radius2
+                        ? 0
+                        : (float) Math.exp(-distance / twoSigmaSquare) / sigmaRoot;
+                total += data[i];
+            }
+
+            for (int i = 0; i < data.length; i++)
+            {
+                data[i] /= total;
+            }
+
+            if (horizontal)
+            {
+                xBlur = new ConvolveOp(new Kernel(size, 1, data), ConvolveOp.EDGE_NO_OP, null);
+            } else
+            {
+                yBlur = new ConvolveOp(new Kernel(1, size, data), ConvolveOp.EDGE_NO_OP, null);
+            }
+        }
+
+        Rectangle dstBounds = new Rectangle(inputBounds);
+        if (horizontal)
+        {
+            dstBounds.grow(size, 0);
+        } else
+        {
+            dstBounds.grow(0, size);
+        }
+
+        return new FilterOp(horizontal ? xBlur : yBlur, dstBounds);
+    }
+}

--- a/svg-core/src/main/java/com/kitfox/svg/Filter.java
+++ b/svg-core/src/main/java/com/kitfox/svg/Filter.java
@@ -61,7 +61,7 @@ public class Filter extends SVGElement
     float height = 1f;
     Point2D filterRes = new Point2D.Double();
     URL href = null;
-    final ArrayList<SVGElement> filterEffects = new ArrayList<SVGElement>();
+    final ArrayList<FilterEffects> filterEffects = new ArrayList<>();
 
     /**
      * Creates a new instance of FillElement
@@ -87,7 +87,7 @@ public class Filter extends SVGElement
 
         if (child instanceof FilterEffects)
         {
-            filterEffects.add(child);
+            filterEffects.add((FilterEffects) child);
         }
     }
 

--- a/svg-core/src/main/java/com/kitfox/svg/FilterEffects.java
+++ b/svg-core/src/main/java/com/kitfox/svg/FilterEffects.java
@@ -36,14 +36,18 @@
 package com.kitfox.svg;
 
 import com.kitfox.svg.xml.StyleAttribute;
+
+import java.awt.Rectangle;
+import java.awt.image.BufferedImageOp;
 import java.net.URI;
 import java.net.URL;
+import java.util.List;
 
 /**
  * @author Mark McKay
  * @author <a href="mailto:mark@kitfox.com">Mark McKay</a>
  */
-public class FilterEffects extends SVGElement
+public abstract class FilterEffects extends SVGElement
 {
     public static final String TAG_NAME = "filtereffects";
     
@@ -60,7 +64,6 @@ public class FilterEffects extends SVGElement
     float y = 0f;
     float width = 1f;
     float height = 1f;
-    String result = "defaultFilterName";
     URL href = null;
 
     /**
@@ -133,6 +136,10 @@ public class FilterEffects extends SVGElement
          throw new SVGException(e);
          }
          */
+    }
+
+    public List<FilterOp> getOperations(Rectangle bounds, float xScale, float yScale) {
+        return null;
     }
 
     public float getX()
@@ -252,5 +259,15 @@ public class FilterEffects extends SVGElement
          */
 
         return stateChange;
+    }
+
+    public static class FilterOp {
+        public final BufferedImageOp op;
+        public final Rectangle requiredImageBounds;
+
+        public FilterOp(BufferedImageOp op, Rectangle requiredImageBounds) {
+            this.op = op;
+            this.requiredImageBounds = requiredImageBounds;
+        }
     }
 }

--- a/svg-core/src/main/java/com/kitfox/svg/Group.java
+++ b/svg-core/src/main/java/com/kitfox/svg/Group.java
@@ -312,6 +312,11 @@ public class Group extends ShapeElement
             SVGElement ele = it.next();
             boolean updateVal = ele.updateTime(curTime);
 
+            if (updateVal && ele instanceof RenderableElement)
+            {
+                ((RenderableElement) ele).setBufferImage(null);
+            }
+
             changeState = changeState || updateVal;
 
             //Update our shape if shape aware children change
@@ -323,6 +328,11 @@ public class Group extends ShapeElement
             {
                 boundingBox = null;
             }
+        }
+
+        if (changeState)
+        {
+            setBufferImage(null);
         }
 
         return changeState;

--- a/svg-core/src/main/java/com/kitfox/svg/ImageSVG.java
+++ b/svg-core/src/main/java/com/kitfox/svg/ImageSVG.java
@@ -256,7 +256,7 @@ public class ImageSVG extends RenderableElement
         AffineTransform curXform = g.getTransform();
         g.transform(xform);
 
-        g.drawImage(img, 0, 0, null);
+        g.drawImage(img, 0, 0, diagram.getCurrentRenderTarget());
 
         g.setTransform(curXform);
         if (oldComp != null)

--- a/svg-core/src/main/java/com/kitfox/svg/RenderableElement.java
+++ b/svg-core/src/main/java/com/kitfox/svg/RenderableElement.java
@@ -56,6 +56,7 @@ abstract public class RenderableElement extends TransformableElement
     AffineTransform cachedXform = null;
 
     Mask cachedMask;
+    Filter filter;
     Shape cachedClip = null;
     public static final int VECTOR_EFFECT_NONE = 0;
     public static final int VECTOR_EFFECT_NON_SCALING_STROKE = 1;
@@ -95,17 +96,12 @@ abstract public class RenderableElement extends TransformableElement
         }
 
         cachedMask = getMask(sty);
+        filter = getFilter(sty);
     }
 
     public void render(Graphics2D g) throws SVGException
     {
-        if (cachedMask != null)
-        {
-            cachedMask.renderElement(g, this);
-        } else
-        {
-            doRender(g);
-        }
+        BufferPainter.paintElement(g, this);
     }
 
     private Mask getMask(StyleAttribute styleAttrib) throws SVGException
@@ -117,6 +113,19 @@ abstract public class RenderableElement extends TransformableElement
                 return null;
             }
             return  (Mask) diagram.getUniverse().getElement(uri);
+        }
+        return null;
+    }
+
+    private Filter getFilter(StyleAttribute styleAttrib) throws SVGException
+    {
+        if (getStyle(styleAttrib.setName("filter"), false)
+            && !"none".equals(styleAttrib.getStringValue())) {
+            URI uri = styleAttrib.getURIValue(getXMLBase());
+            if (uri == null) {
+                return null;
+            }
+            return  (Filter) diagram.getUniverse().getElement(uri);
         }
         return null;
     }

--- a/svg-core/src/main/java/com/kitfox/svg/RenderableElement.java
+++ b/svg-core/src/main/java/com/kitfox/svg/RenderableElement.java
@@ -62,6 +62,8 @@ abstract public class RenderableElement extends TransformableElement
     public static final int VECTOR_EFFECT_NON_SCALING_STROKE = 1;
     int vectorEffect;
 
+    private BufferPainter.Cache bufferCache;
+
     /**
      * Creates a new instance of BoundedElement
      */
@@ -72,6 +74,16 @@ abstract public class RenderableElement extends TransformableElement
     public RenderableElement(String id, SVGElement parent)
     {
         super(id, parent);
+    }
+
+    BufferPainter.Cache getBufferCache()
+    {
+        return bufferCache;
+    }
+
+    void setBufferImage(BufferPainter.Cache bufferCache)
+    {
+        this.bufferCache = bufferCache;
     }
 
     @Override

--- a/svg-core/src/main/java/com/kitfox/svg/SVGDiagram.java
+++ b/svg-core/src/main/java/com/kitfox/svg/SVGDiagram.java
@@ -3,16 +3,16 @@
  * Copyright (c) 2004, Mark McKay
  * All rights reserved.
  *
- * Redistribution and use in source and binary forms, with or 
+ * Redistribution and use in source and binary forms, with or
  * without modification, are permitted provided that the following
  * conditions are met:
  *
- *   - Redistributions of source code must retain the above 
+ *   - Redistributions of source code must retain the above
  *     copyright notice, this list of conditions and the following
  *     disclaimer.
  *   - Redistributions in binary form must reproduce the above
  *     copyright notice, this list of conditions and the following
- *     disclaimer in the documentation and/or other materials 
+ *     disclaimer in the documentation and/or other materials
  *     provided with the distribution.
  *
  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
@@ -26,8 +26,8 @@
  * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
  * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
  * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
- * OF THE POSSIBILITY OF SUCH DAMAGE. 
- * 
+ * OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
  * Mark McKay can be contacted at mark@kitfox.com.  Salamander and other
  * projects can be found at http://www.kitfox.com
  *
@@ -36,6 +36,7 @@
 
 package com.kitfox.svg;
 
+import javax.swing.JComponent;
 import java.awt.Graphics2D;
 import java.awt.Rectangle;
 import java.awt.geom.AffineTransform;
@@ -59,15 +60,16 @@ import java.util.logging.Logger;
 public class SVGDiagram implements Serializable
 {
     public static final long serialVersionUID = 0;
-    
+
     //Indexes elements within this SVG diagram
     final HashMap<String, SVGElement> idMap = new HashMap<String, SVGElement>();
 
     SVGRoot root;
     final SVGUniverse universe;
+    private JComponent renderTarget;
 
     /**
-     * This is used by the SVGRoot to determine the width of the 
+     * This is used by the SVGRoot to determine the width of the
      */
     private Rectangle deviceViewport = new Rectangle(100, 100);
 
@@ -101,6 +103,18 @@ public class SVGDiagram implements Serializable
         this.xmlBase = xmlBase;
     }
 
+    JComponent getCurrentRenderTarget()
+    {
+        return renderTarget;
+    }
+
+    public void render(JComponent c, Graphics2D g) throws SVGException
+    {
+        renderTarget = c;
+        root.renderToViewport(g);
+        renderTarget = null;
+    }
+
     /**
      * Draws this diagram to the passed graphics context
      * @param g
@@ -108,13 +122,13 @@ public class SVGDiagram implements Serializable
      */
     public void render(Graphics2D g) throws SVGException
     {
-        root.renderToViewport(g);
+        render(null, g);
     }
-    
+
     /**
      * Searches thorough the scene graph for all RenderableElements that have
      * shapes that contain the passed point.
-     * 
+     *
      * For every shape which contains the pick point, a List containing the
      * path to the node is added to the return list.  That is, the result of
      * SVGElement.getPath() is added for each entry.
@@ -128,16 +142,16 @@ public class SVGDiagram implements Serializable
     {
         return pick(point, false, retVec);
     }
-    
+
     public List<List<SVGElement>> pick(Point2D point, boolean boundingBox, List<List<SVGElement>> retVec) throws SVGException
     {
         if (retVec == null)
         {
             retVec = new ArrayList<List<SVGElement>>();
         }
-        
+
         root.pick(point, boundingBox, retVec);
-        
+
         return retVec;
     }
 
@@ -145,16 +159,16 @@ public class SVGDiagram implements Serializable
     {
         return pick(pickArea, false, retVec);
     }
-    
+
     public List<List<SVGElement>> pick(Rectangle2D pickArea, boolean boundingBox, List<List<SVGElement>> retVec) throws SVGException
     {
         if (retVec == null)
         {
             retVec = new ArrayList<List<SVGElement>>();
         }
-        
+
         root.pick(pickArea, new AffineTransform(), boundingBox, retVec);
-        
+
         return retVec;
     }
 
@@ -178,17 +192,17 @@ public class SVGDiagram implements Serializable
         if (root == null) return 0;
         return root.getDeviceWidth();
     }
-    
+
     public float getHeight()
     {
         if (root == null) return 0;
         return root.getDeviceHeight();
     }
-    
+
     /**
      * Returns the viewing rectangle of this diagram in device coordinates.
      * @param rect
-     * @return 
+     * @return
      */
     public Rectangle2D getViewRect(Rectangle2D rect)
     {
@@ -264,7 +278,7 @@ public class SVGDiagram implements Serializable
                 root.build();
             } catch (SVGException ex)
             {
-                Logger.getLogger(SVGConst.SVG_LOGGER).log(Level.WARNING, 
+                Logger.getLogger(SVGConst.SVG_LOGGER).log(Level.WARNING,
                     "Could not build document", ex);
             }
         }

--- a/svg-core/src/main/java/com/kitfox/svg/SVGLoader.java
+++ b/svg-core/src/main/java/com/kitfox/svg/SVGLoader.java
@@ -102,6 +102,7 @@ public class SVGLoader extends DefaultHandler
         nodeClasses.put("desc", Desc.class);
         nodeClasses.put("ellipse", Ellipse.class);
         nodeClasses.put("filter", Filter.class);
+        nodeClasses.put(FeGaussianBlur.TAG_NAME, FeGaussianBlur.class);
         nodeClasses.put("font", Font.class);
         nodeClasses.put("font-face", FontFace.class);
         nodeClasses.put("g", Group.class);

--- a/svg-core/src/main/java/com/kitfox/svg/app/beans/SVGPanel.java
+++ b/svg-core/src/main/java/com/kitfox/svg/app/beans/SVGPanel.java
@@ -132,7 +132,7 @@ public class SVGPanel extends JPanel
         {
             try
             {
-                diagram.render(g);
+                diagram.render(this, g);
                 g.setRenderingHint(RenderingHints.KEY_ANTIALIASING, oldAliasHint);
             }
             catch (SVGException e)

--- a/svg-core/src/main/java/com/kitfox/svg/pathcmd/PathParser.java
+++ b/svg-core/src/main/java/com/kitfox/svg/pathcmd/PathParser.java
@@ -1,0 +1,251 @@
+/*
+ * SVG Salamander
+ * Copyright (c) 2004, Mark McKay
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or
+ * without modification, are permitted provided that the following
+ * conditions are met:
+ *
+ *   - Redistributions of source code must retain the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer.
+ *   - Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/or other materials
+ *     provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ * INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+ * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+ * OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ * Mark McKay can be contacted at mark@kitfox.com.  Salamander and other
+ * projects can be found at http://www.kitfox.com
+ *
+ */
+package com.kitfox.svg.pathcmd;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * A helper for parsing {@link PathCommand}s.
+ *
+ * @author Jannis Weis
+ */
+public class PathParser
+{
+    private final String input;
+    private final int inputLength;
+    private int index;
+    private char currentCommand;
+
+    public PathParser(String input) {
+        this.input = input;
+        this.inputLength = input.length();
+    }
+
+    private boolean isCommandChar(char c)
+    {
+        return c >= 'A' && c <= 'Z' || c >= 'a' && c <= 'z';
+    }
+
+    private boolean isWhiteSpaceOrSeparator(char c)
+    {
+        return c <= ' ' || c == ',';
+    }
+
+    private char peek()
+    {
+        return input.charAt(index);
+    }
+
+    private void consume()
+    {
+        index++;
+    }
+
+    private boolean hasNext()
+    {
+        return index < inputLength;
+    }
+
+    // This only checks for the rough structure of a number as we need to know
+    // when to separate the next token.
+    // Explicit parsing is done by Float#parseFloat.
+    private boolean isValidNumberChar(char c, NumberCharState state)
+    {
+        boolean valid = '0' <= c && c <= '9';
+        if (valid && state.iteration == 1 && input.charAt(index - 1) == '0')
+        {
+            // Break up combined zeros into multiple numbers.
+            return false;
+        }
+        state.signAllowed = state.signAllowed && !valid;
+        if (state.dotAllowed && !valid)
+        {
+            valid = c == '.';
+            state.dotAllowed = !valid;
+        }
+        if (state.signAllowed && !valid)
+        {
+            valid = c == '+' || c == '-';
+            state.signAllowed = valid;
+        }
+        if (state.exponentAllowed && !valid)
+        {
+            // Possible exponent notation. Needs at least one preceding number
+            valid = c == 'e' || c == 'E';
+            state.exponentAllowed = !valid;
+            state.signAllowed = valid;
+        }
+        state.iteration++;
+        return valid;
+    }
+
+    private void consumeWhiteSpaceOrSeparator() {
+        while (hasNext() && isWhiteSpaceOrSeparator(peek())) {
+            consume();
+        }
+    }
+
+    private float nextFloat()
+    {
+        int start = index;
+        NumberCharState state = new NumberCharState();
+        while (hasNext() && isValidNumberChar(peek(), state)) {
+            consume();
+        }
+        int end = index;
+        consumeWhiteSpaceOrSeparator();
+        String token = input.substring(start, end);
+        try
+        {
+            return Float.parseFloat(token);
+        } catch (NumberFormatException e)
+        {
+            String msg = "Unexpected element while parsing cmd '" + currentCommand
+                    + "' encountered token '" + token + "' rest=" + input.substring(start, Math.min(input.length(), start + 10))
+                    + " (index=" + index + " in input=" + input + ")";
+            throw new IllegalStateException(msg, e);
+        }
+    }
+
+    public PathCommand[] parsePathCommand()
+    {
+        List<PathCommand> commands = new ArrayList<>();
+
+        currentCommand = 'Z';
+        while (hasNext())
+        {
+            char peekChar = peek();
+            if (isCommandChar(peekChar))
+            {
+                consume();
+                currentCommand = peekChar;
+            }
+            consumeWhiteSpaceOrSeparator();
+
+            PathCommand cmd;
+            switch (currentCommand)
+            {
+                case 'M':
+                    cmd = new MoveTo(false, nextFloat(), nextFloat());
+                    currentCommand = 'L';
+                    break;
+                case 'm':
+                    cmd = new MoveTo(true, nextFloat(), nextFloat());
+                    currentCommand = 'l';
+                    break;
+                case 'L':
+                    cmd = new LineTo(false, nextFloat(), nextFloat());
+                    break;
+                case 'l':
+                    cmd = new LineTo(true, nextFloat(), nextFloat());
+                    break;
+                case 'H':
+                    cmd = new Horizontal(false, nextFloat());
+                    break;
+                case 'h':
+                    cmd = new Horizontal(true, nextFloat());
+                    break;
+                case 'V':
+                    cmd = new Vertical(false, nextFloat());
+                    break;
+                case 'v':
+                    cmd = new Vertical(true, nextFloat());
+                    break;
+                case 'A':
+                    cmd = new Arc(false, nextFloat(), nextFloat(),
+                                  nextFloat(),
+                                  nextFloat() == 1f, nextFloat() == 1f,
+                                  nextFloat(), nextFloat());
+                    break;
+                case 'a':
+                    cmd = new Arc(true, nextFloat(), nextFloat(),
+                                  nextFloat(),
+                                  nextFloat() == 1f, nextFloat() == 1f,
+                                  nextFloat(), nextFloat());
+                    break;
+                case 'Q':
+                    cmd = new Quadratic(false, nextFloat(), nextFloat(),
+                                        nextFloat(), nextFloat());
+                    break;
+                case 'q':
+                    cmd = new Quadratic(true, nextFloat(), nextFloat(),
+                                        nextFloat(), nextFloat());
+                    break;
+                case 'T':
+                    cmd = new QuadraticSmooth(false, nextFloat(), nextFloat());
+                    break;
+                case 't':
+                    cmd = new QuadraticSmooth(true, nextFloat(), nextFloat());
+                    break;
+                case 'C':
+                    cmd = new Cubic(false, nextFloat(), nextFloat(),
+                                    nextFloat(), nextFloat(),
+                                    nextFloat(), nextFloat());
+                    break;
+                case 'c':
+                    cmd = new Cubic(true, nextFloat(), nextFloat(),
+                                    nextFloat(), nextFloat(),
+                                    nextFloat(), nextFloat());
+                    break;
+                case 'S':
+                    cmd = new CubicSmooth(false, nextFloat(), nextFloat(),
+                                          nextFloat(), nextFloat());
+                    break;
+                case 's':
+                    cmd = new CubicSmooth(true, nextFloat(), nextFloat(),
+                                          nextFloat(), nextFloat());
+                    break;
+                case 'Z':
+                case 'z':
+                    cmd = new Terminal();
+                    break;
+                default:
+                    throw new RuntimeException("Invalid path element "
+                            + currentCommand + "(at index=" + index + " in input=" + input + ")");
+            }
+            commands.add(cmd);
+        }
+        return commands.toArray(new PathCommand[0]);
+    }
+
+    private static class NumberCharState
+    {
+        int iteration = 0;
+        boolean dotAllowed = true;
+        boolean signAllowed = true;
+        boolean exponentAllowed = true;
+    }
+}


### PR DESCRIPTION
This implements a rudimentary gaussian blur filter.

Because filters like mask need to facilitate painting to an off-screen buffer,
we extract the logic for this into a separate class outside of Mask.
Then the size of the buffer is first adjusted to suit the installed filters.
After applying the filters the mask is painted as usual.
Notably this implementation currently doesn't support any filter specific
attributes such as 'in', 'feOffset', 'feMergeMode' etc.

This implementation is capable of rendering the logo from #44, though it isn't particularly fast.

This PR includes the commit from #81, as it was necessary for the logo in #44 to load correctly. 