### PR TITLE
#91 fix static matchers, work with static Patterns only

### DIFF
--- a/svg-core/src/main/java/com/kitfox/svg/animation/AnimateMotion.java
+++ b/svg-core/src/main/java/com/kitfox/svg/animation/AnimateMotion.java
@@ -60,7 +60,7 @@ public class AnimateMotion extends AnimateXform
 {
     public static final String TAG_NAME = "animateMotion";
     
-    static final Matcher matchPoint = Pattern.compile("\\s*(\\d+)[^\\d]+(\\d+)\\s*").matcher("");
+    static final Pattern patPoint = Pattern.compile("\\s*(\\d+)[^\\d]+(\\d+)\\s*");
     
 //    protected double fromValue;
 //    protected double toValue;
@@ -140,7 +140,7 @@ public class AnimateMotion extends AnimateXform
         {
             Point2D.Float ptFrom = new Point2D.Float(), ptTo = new Point2D.Float();
 
-            matchPoint.reset(from);
+            Matcher matchPoint = patPoint.matcher(from);
             if (matchPoint.matches())
             {
                 setPoint(ptFrom, matchPoint.group(1), matchPoint.group(2));

--- a/svg-core/src/main/java/com/kitfox/svg/animation/TimeBase.java
+++ b/svg-core/src/main/java/com/kitfox/svg/animation/TimeBase.java
@@ -49,8 +49,8 @@ import java.util.regex.*;
  */
 abstract public class TimeBase
 {
-    static final Matcher matchIndefinite = Pattern.compile("\\s*indefinite\\s*").matcher("");
-    static final Matcher matchUnitTime = Pattern.compile("\\s*([-+]?((\\d*\\.\\d+)|(\\d+))([-+]?[eE]\\d+)?)\\s*(h|min|s|ms)?\\s*").matcher("");
+	static final Pattern patIndefinite = Pattern.compile("\\s*indefinite\\s*");
+	static final Pattern patUnitTime = Pattern.compile("\\s*([-+]?((\\d*\\.\\d+)|(\\d+))([-+]?[eE]\\d+)?)\\s*(h|min|s|ms)?\\s*");
     
     /*
     public static TimeBase parseTime(String text) 
@@ -68,10 +68,10 @@ abstract public class TimeBase
     
     protected static TimeBase parseTimeComponent(String text)
     {
-        matchIndefinite.reset(text);
+        Matcher matchIndefinite = patIndefinite.matcher(text);
         if (matchIndefinite.matches()) return new TimeIndefinite();
         
-        matchUnitTime.reset(text);
+        Matcher matchUnitTime = patUnitTime.matcher(text);
         if (matchUnitTime.matches())
         {
             String val = matchUnitTime.group(1);

--- a/svg-core/src/main/java/com/kitfox/svg/xml/StyleAttribute.java
+++ b/svg-core/src/main/java/com/kitfox/svg/xml/StyleAttribute.java
@@ -53,8 +53,7 @@ public class StyleAttribute implements Serializable
     public static final long serialVersionUID = 0;
 
     static final Pattern patternUrl = Pattern.compile("\\s*url\\((.*)\\)\\s*");
-    static final Matcher matchFpNumUnits = Pattern.compile("\\s*([-+]?((\\d*\\.\\d+)|(\\d+))([-+]?[eE]\\d+)?)\\s*(px|cm|mm|in|pc|pt|em|ex)\\s*").matcher("");
-    
+    static final Pattern patternFpNumUnits = Pattern.compile("\\s*([-+]?((\\d*\\.\\d+)|(\\d+))([-+]?[eE]\\d+)?)\\s*(px|cm|mm|in|pc|pt|em|ex)\\s*");
     String name;
     String stringValue;
 
@@ -140,9 +139,9 @@ public class StyleAttribute implements Serializable
     }
 
     public String getUnits() {
-        matchFpNumUnits.reset(stringValue);
-        if (!matchFpNumUnits.matches()) return null;
-        return matchFpNumUnits.group(6);
+        Matcher m = patternFpNumUnits.matcher(stringValue);
+        if (!m.matches()) return null;
+        return m.group(6);
     }
 
     public NumberWithUnits getNumberWithUnits() {

--- a/svg-core/src/main/java/com/kitfox/svg/xml/XMLParseUtil.java
+++ b/svg-core/src/main/java/com/kitfox/svg/xml/XMLParseUtil.java
@@ -52,9 +52,10 @@ import java.util.logging.Logger;
  */
 public class XMLParseUtil
 {
-    static final Matcher fpMatch = Pattern.compile("([-+]?((\\d*\\.\\d+)|(\\d+))([eE][+-]?\\d+)?)(\\%|in|cm|mm|pt|pc|px|em|ex)?").matcher("");
-    static final Matcher intMatch = Pattern.compile("[-+]?\\d+").matcher("");
-    static final Matcher quoteMatch = Pattern.compile("^'|'$").matcher("");
+    static final Pattern fpPat = Pattern.compile("([-+]?((\\d*\\.\\d+)|(\\d+))([eE][+-]?\\d+)?)(\\%|in|cm|mm|pt|pc|px|em|ex)?");
+    static final Pattern intPat = Pattern.compile("[-+]?\\d+");
+    static final Pattern quotePat = Pattern.compile("^'|'$");
+
 
     /** Creates a new instance of XMLParseUtil */
     private XMLParseUtil()
@@ -118,8 +119,8 @@ public class XMLParseUtil
 
     public static boolean isDouble(String val)
     {
-        fpMatch.reset(val);
-        return fpMatch.matches();
+        Matcher m = fpPat.matcher(val);
+        return m.matches();
     }
     
     public static double parseDouble(String val)
@@ -145,10 +146,10 @@ public class XMLParseUtil
     {
         if (val == null) return 0;
 
-        fpMatch.reset(val);
+        Matcher matcher = fpPat.matcher(val);
         try
         {
-            if (!fpMatch.find()) return 0;
+            if (!matcher.find()) return 0;
         }
         catch (StringIndexOutOfBoundsException e)
         {
@@ -156,7 +157,7 @@ public class XMLParseUtil
                 "XMLParseUtil: regex parse problem: '" + val + "'", e);
         }
 
-        val = fpMatch.group(1);
+        val = matcher.group(1);
         //System.err.println("Parsing " + val);
 
         double retVal = 0;
@@ -174,7 +175,7 @@ public class XMLParseUtil
                 pixPerInch = 72;
             }
             final float inchesPerCm = .3936f;
-            final String units = fpMatch.group(6);
+            final String units = matcher.group(6);
             
             if ("%".equals(units)) retVal /= 100;
             else if ("in".equals(units))
@@ -212,13 +213,12 @@ public class XMLParseUtil
     public synchronized static double[] parseDoubleList(String list)
     {
         if (list == null) return null;
-
-        fpMatch.reset(list);
+        Matcher matcher = fpPat.matcher(list);
 
         LinkedList<Double> doubList = new LinkedList<Double>();
-        while (fpMatch.find())
+        while (matcher.find())
         {
-            String val = fpMatch.group(1);
+            String val = matcher.group(1);
             doubList.add(Double.valueOf(val));
         }
 
@@ -255,18 +255,17 @@ public class XMLParseUtil
     public synchronized static float findFloat(String val)
     {
         if (val == null) return 0f;
+        Matcher matcher = fpPat.matcher(val);
+        if (!matcher.find()) return 0f;
 
-        fpMatch.reset(val);
-        if (!fpMatch.find()) return 0f;
-
-        val = fpMatch.group(1);
+        val = matcher.group(1);
         //System.err.println("Parsing " + val);
 
         float retVal = 0f;
         try
         {
             retVal = Float.parseFloat(val);
-            String units = fpMatch.group(6);
+            String units = matcher.group(6);
             if ("%".equals(units)) retVal /= 100;
         }
         catch (Exception e)
@@ -277,13 +276,12 @@ public class XMLParseUtil
     public synchronized static float[] parseFloatList(String list)
     {
         if (list == null) return null;
-
-        fpMatch.reset(list);
+        Matcher matcher = fpPat.matcher(list);
 
         LinkedList<Float> floatList = new LinkedList<Float>();
-        while (fpMatch.find())
+        while (matcher.find())
         {
-            String val = fpMatch.group(1);
+            String val = matcher.group(1);
             floatList.add(Float.valueOf(val));
         }
 
@@ -317,11 +315,10 @@ public class XMLParseUtil
     public static int findInt(String val)
     {
         if (val == null) return 0;
+        Matcher matcher = intPat.matcher(val);
+        if (!matcher.find()) return 0;
 
-        intMatch.reset(val);
-        if (!intMatch.find()) return 0;
-
-        val = intMatch.group();
+        val = matcher.group();
         //System.err.println("Parsing " + val);
 
         int retVal = 0;
@@ -335,13 +332,12 @@ public class XMLParseUtil
     public static int[] parseIntList(String list)
     {
         if (list == null) return null;
-
-        intMatch.reset(list);
+        Matcher matcher = intPat.matcher(list);
 
         LinkedList<Integer> intList = new LinkedList<Integer>();
-        while (intMatch.find())
+        while (matcher.find())
         {
-            String val = intMatch.group();
+            String val = matcher.group();
             intList.add(Integer.valueOf(val));
         }
 
@@ -821,9 +817,8 @@ public class XMLParseUtil
             {
                 continue;
             }
-
             String key = styles[i].substring(0, colon).trim().intern();
-            String value = quoteMatch.reset(styles[i].substring(colon + 1).trim()).replaceAll("").intern();
+            String value = quotePat.matcher(styles[i].substring(colon + 1).trim()).replaceAll("").intern();
 
             map.put(key, new StyleAttribute(key, value));
         }


### PR DESCRIPTION
Matchers are stateful, static fields are accessed in all Threads, there is no way to make parsing threadsafe, even mit multiple SVGUniverse objects.
After the change, every thread will create own Matcher objects (stateful) from the static compiled Patterns.