### PR TITLE
Font family attribute is not splitted correctly

### DIFF
--- a/svg-core/src/main/java/com/kitfox/svg/util/FontUtil.java
+++ b/svg-core/src/main/java/com/kitfox/svg/util/FontUtil.java
@@ -147,7 +147,8 @@ public final class FontUtil
             }
         }
 
-        return new FontInfo(fontFamily.split(","), fontSize, fontStyle, fontWeight, letterSpacing);
+        String[] split = fontFamily.split("\\s*#\\s*");
+        return new FontInfo(split, fontSize, fontStyle, fontWeight, letterSpacing);
     }
 
     public static Font getFont(FontInfo info, SVGDiagram diagram)


### PR DESCRIPTION
From here:
https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/font-family
we can see an example of a font family attribute:
```
<svg viewBox="0 0 200 30" xmlns="http://www.w3.org/2000/svg">
  <text y="20" font-family="Arial, Helvetica, sans-serif">Sans serif</text>
</svg>
```
We can see that the font families are separated by commas and spaces.

In the class FontUtil.parseFontInfo(SVGElement, StyleAttribute):150 we can see 
`fontFamily.split(",")`. 
This adds extra spaces in Helvetica and sans-serif and the load of the font can fail when Arial family is not available.

To fix the bug I have added a regex to split and trim in one shot. See here:
https://stackoverflow.com/questions/41953388/java-split-and-trim-in-one-shot

