### PR TITLE
Performance improvements

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1,0 +1,12 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <groupId>com.github.blackears</groupId>
+    <artifactId>svgSalamanderParent</artifactId>
+    <version>1.1.5-SNAPSHOT</version>
+    <packaging>pom</packaging>
+    <modules>
+        <module>svg-core</module>
+        <module>svg-example</module>
+    </modules>
+</project>

--- a/svg-core/pom.xml
+++ b/svg-core/pom.xml
@@ -68,7 +68,7 @@
         <dependency>
             <groupId>org.apache.ant</groupId>
             <artifactId>ant</artifactId>
-            <version>1.9.13</version>
+            <version>1.10.13</version>
             <optional>true</optional>
         </dependency>
     </dependencies>

--- a/svg-core/pom.xml
+++ b/svg-core/pom.xml
@@ -4,12 +4,17 @@
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
-    <groupId>com.github.blackears</groupId>
+    <parent>
+        <groupId>com.github.blackears</groupId>
+        <artifactId>svgSalamanderParent</artifactId>
+        <version>1.1.5-SNAPSHOT</version>
+        <relativePath>../pom.xml</relativePath>
+    </parent>
+
     <artifactId>svgSalamander</artifactId>
-    <version>1.1.5</version>
     <packaging>jar</packaging>
 
-    <name>com.github.blackears:svgSalamander</name>
+    <name>${groupId}:${artifactId}</name>
     <description>A tool for displaying and playing SVG content using the Java2D.</description>
     <url>https://github.com/blackears/svgSalamander</url>
 

--- a/svg-core/src/main/java/com/kitfox/svg/pathcmd/PathParser.java
+++ b/svg-core/src/main/java/com/kitfox/svg/pathcmd/PathParser.java
@@ -44,6 +44,16 @@ import java.util.List;
  */
 public class PathParser
 {
+    /*
+     * This was part of NumberCharState. Unfortunately, it is not inlined as of Java 20. Maybe when Java has value
+     * classes this will change.
+     */
+    int iteration = 0;
+    boolean dotAllowed = true;
+    boolean signAllowed = true;
+    boolean exponentAllowed = true;
+    /* End NumberCharState class information */
+
     private final String input;
     private final int inputLength;
     private int index;
@@ -82,7 +92,7 @@ public class PathParser
     // This only checks for the rough structure of a number as we need to know
     // when to separate the next token.
     // Explicit parsing is done by Float#parseFloat.
-    private boolean isValidNumberChar(char c, NumberCharState state)
+    private boolean isValidNumberChar(char c, PathParser state)
     {
         boolean valid = '0' <= c && c <= '9';
         if (valid && state.iteration == 1 && input.charAt(index - 1) == '0')
@@ -121,7 +131,7 @@ public class PathParser
     private float nextFloat()
     {
         int start = index;
-        NumberCharState state = new NumberCharState();
+        PathParser state = this.resetNumberCharState();
         while (hasNext() && isValidNumberChar(peek(), state)) {
             consume();
         }
@@ -241,11 +251,15 @@ public class PathParser
         return commands.toArray(new PathCommand[0]);
     }
 
-    private static class NumberCharState
-    {
-        int iteration = 0;
-        boolean dotAllowed = true;
-        boolean signAllowed = true;
-        boolean exponentAllowed = true;
+    /**
+     * Reset the NumberCharState
+     * @return {this}, for ease of changing back to a NumberCharState class later.
+     */
+    private PathParser resetNumberCharState() {
+        this.iteration = 0;
+        this.dotAllowed = true;
+        this.signAllowed = true;
+        this.exponentAllowed = true;
+        return this;
     }
 }

--- a/svg-core/src/main/java/com/kitfox/svg/xml/ColorTable.java
+++ b/svg-core/src/main/java/com/kitfox/svg/xml/ColorTable.java
@@ -48,6 +48,9 @@ import java.util.regex.Pattern;
 public class ColorTable 
 {
 
+    private static final String NUMBER_REGEX = "\\s*(((\\d+)(\\.\\d*)?)|(\\.\\d+))(%)?\\s*";
+    private static final Pattern PATTERN_RGB = Pattern.compile("rgb\\(" + NUMBER_REGEX + "," + NUMBER_REGEX + "," + NUMBER_REGEX + "\\)", Pattern.CASE_INSENSITIVE);
+
     static final Map<String, Color> colorTable;
     static {
         HashMap<String, Color> table = new HashMap<String, Color>();
@@ -240,10 +243,7 @@ public class ColorTable
         }
         else
         {
-            final String number = "\\s*(((\\d+)(\\.\\d*)?)|(\\.\\d+))(%)?\\s*";
-            final Matcher rgbMatch = Pattern.compile("rgb\\(" + number + "," + number + "," + number + "\\)", Pattern.CASE_INSENSITIVE).matcher("");
-
-            rgbMatch.reset(val);
+            final Matcher rgbMatch = PATTERN_RGB.matcher(val);
             if (rgbMatch.matches())
             {
                 float rr = Float.parseFloat(rgbMatch.group(1));

--- a/svg-core/src/main/java/com/kitfox/svg/xml/StyleAttribute.java
+++ b/svg-core/src/main/java/com/kitfox/svg/xml/StyleAttribute.java
@@ -52,6 +52,8 @@ public class StyleAttribute implements Serializable
 {
     public static final long serialVersionUID = 0;
 
+    private static final Pattern PATTERN_WHITESPACE = Pattern.compile("\\s+");
+    private static final Pattern PATTERN_JDK_5_WORKAROUND = Pattern.compile("[a-zA-Z]:!\\\\.*");
     static final Pattern patternUrl = Pattern.compile("\\s*url\\((.*)\\)\\s*");
     static final Pattern patternFpNumUnits = Pattern.compile("\\s*([-+]?((\\d*\\.\\d+)|(\\d+))([-+]?[eE]\\d+)?)\\s*(px|cm|mm|in|pc|pt|em|ex)\\s*");
     String name;
@@ -262,13 +264,12 @@ public class StyleAttribute implements Serializable
     {
         try {
             String fragment = parseURLFn();
-            if (fragment == null) fragment = stringValue.replaceAll("\\s+", "");
+            if (fragment == null) fragment = PATTERN_WHITESPACE.matcher(stringValue).replaceAll("");
             if (fragment == null) return null;
             
             //======================
             //This gets around a bug in the 1.5.0 JDK
-            if (Pattern.matches("[a-zA-Z]:!\\\\.*", fragment))
-            {
+            if (PATTERN_JDK_5_WORKAROUND.matcher(fragment).matches()) {
                 File file = new File(fragment);
                 return file.toURI();
             }

--- a/svg-core/src/main/java/com/kitfox/svg/xml/XMLParseUtil.java
+++ b/svg-core/src/main/java/com/kitfox/svg/xml/XMLParseUtil.java
@@ -52,6 +52,8 @@ import java.util.logging.Logger;
  */
 public class XMLParseUtil
 {
+    private static final Pattern PATTERN_WHITESPACE = Pattern.compile("[^\\s]+");
+    private static final Pattern PATTERN_SEMI_COLON = Pattern.compile(";");
     static final Pattern fpPat = Pattern.compile("([-+]?((\\d*\\.\\d+)|(\\d+))([eE][+-]?\\d+)?)(\\%|in|cm|mm|pt|pc|px|em|ex)?");
     static final Pattern intPat = Pattern.compile("[-+]?\\d+");
     static final Pattern quotePat = Pattern.compile("^'|'$");
@@ -103,9 +105,7 @@ public class XMLParseUtil
 
     public static String[] parseStringList(String list)
     {
-//        final Pattern patWs = Pattern.compile("\\s+");
-        final Matcher matchWs = Pattern.compile("[^\\s]+").matcher("");
-        matchWs.reset(list);
+        final Matcher matchWs = PATTERN_WHITESPACE.matcher(list);
 
         LinkedList<String> matchList = new LinkedList<String>();
         while (matchWs.find())
@@ -735,7 +735,7 @@ public class XMLParseUtil
             try { eleVal = Integer.parseInt(valS); }
             catch (Exception e) {}
 
-            elementCache.addLast(new Integer(eleVal));
+            elementCache.addLast(Integer.valueOf(eleVal));
         }
 
         int[] retArr = new int[elementCache.size()];
@@ -801,13 +801,12 @@ public class XMLParseUtil
      * @param map - A map to which these styles will be added
      */
     public static HashMap<String, StyleAttribute> parseStyle(String styleString, HashMap<String, StyleAttribute> map) {
-        final Pattern patSemi = Pattern.compile(";");
 
-        String[] styles = patSemi.split(styleString);
+        String[] styles = PATTERN_SEMI_COLON.split(styleString);
 
         for (int i = 0; i < styles.length; i++)
         {
-            if (styles[i].length() == 0)
+            if (styles[i].isEmpty())
             {
                 continue;
             }

--- a/svg-core/src/main/java/module-info.java
+++ b/svg-core/src/main/java/module-info.java
@@ -26,7 +26,6 @@
 
 module com.kitfox.svgSalamander {
     requires static ant;
-    requires static ant.launcher;
     requires java.desktop;
     requires java.xml;
     requires java.logging;

--- a/svg-example/pom.xml
+++ b/svg-example/pom.xml
@@ -3,10 +3,14 @@
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>com.github.blackears</groupId>
+        <artifactId>svgSalamanderParent</artifactId>
+        <version>1.1.5-SNAPSHOT</version>
+        <relativePath>../pom.xml</relativePath>
+    </parent>
 
-    <groupId>com.github.blackears</groupId>
     <artifactId>svgSalamander-examples</artifactId>
-    <version>1.1.5-SNAPSHOT</version>
     <packaging>jar</packaging>
 
     <name>com.kitfox:svgSalamander Examples</name>
@@ -55,20 +59,10 @@
         </testResources>
     </build>
     <dependencies>
-        <!--
-<dependency>
-    <groupId>${project.groupId}</groupId>
-    <artifactId>svgSalamander</artifactId>
-    <version>1.1.5</version>
-</dependency>
-        -->
         <dependency>
-            <groupId>${project.groupId}</groupId>
+            <groupId>${groupId}</groupId>
             <artifactId>svgSalamander</artifactId>
-            <version>1.1.5</version>
-            <scope>system</scope>
-            <systemPath>${project.basedir}/../svg-core/target/svgSalamander-1.1.5.jar</systemPath>
+            <version>${version}</version>
         </dependency>
-                
     </dependencies>
 </project>


### PR DESCRIPTION
When I was profiling JOSM with the `Name Suggestion Index` enabled during startup, I noticed that a good chunk of memory allocations were coming from `Pattern` instantiations and `NumberCharState`.

Looking at the remaining allocations, `Float.parseFloat` in `PathParser.nextFloat` are the primary drivers.